### PR TITLE
chore: 각 앱 Dockerfile 추가 (#8)

### DIFF
--- a/apps/ai/.dockerignore
+++ b/apps/ai/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+.venv
+.env*
+.git

--- a/apps/ai/Dockerfile
+++ b/apps/ai/Dockerfile
@@ -1,0 +1,23 @@
+# ---- builder ----
+FROM python:3.12-slim AS builder
+WORKDIR /app
+
+RUN pip install uv
+COPY requirements.txt ./
+RUN uv pip install --system --no-cache -r requirements.txt
+
+# ---- runner ----
+FROM python:3.12-slim AS runner
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 fastapi && \
+    adduser --system --uid 1001 --gid 1001 fastapi
+
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --chown=fastapi:fastapi . .
+
+USER fastapi
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,4 @@
+build
+.gradle
+.env*
+.git

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,25 @@
+# ---- builder ----
+FROM gradle:8.7-jdk21 AS builder
+WORKDIR /app
+COPY build.gradle.kts settings.gradle.kts gradle.properties* ./
+COPY gradle ./gradle
+
+# 의존성 캐시 레이어
+RUN gradle dependencies --no-daemon || true
+
+COPY src ./src
+RUN gradle bootJar --no-daemon -x test
+
+# ---- runner ----
+FROM eclipse-temurin:21-jre-alpine AS runner
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 spring && \
+    adduser --system --uid 1001 --ingroup spring spring
+
+COPY --from=builder --chown=spring:spring /app/build/libs/*.jar app.jar
+
+USER spring
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]

--- a/apps/mcp/.dockerignore
+++ b/apps/mcp/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env*
+.git

--- a/apps/mcp/Dockerfile
+++ b/apps/mcp/Dockerfile
@@ -1,0 +1,25 @@
+# ---- builder ----
+FROM oven/bun:1 AS builder
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+RUN bun run build
+
+# ---- runner ----
+FROM oven/bun:1-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 mcp && \
+    adduser --system --uid 1001 --ingroup mcp mcp
+
+COPY --from=builder --chown=mcp:mcp /app/dist ./dist
+COPY --from=builder --chown=mcp:mcp /app/node_modules ./node_modules
+COPY --from=builder --chown=mcp:mcp /app/package.json ./
+
+USER mcp
+EXPOSE 3001
+
+CMD ["bun", "run", "dist/index.js"]

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env*
+.git

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,32 @@
+# ---- deps ----
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN npm install -g bun && bun install --frozen-lockfile
+
+# ---- builder ----
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm install -g bun && bun run build
+
+# ---- runner ----
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- web(Next.js), api(Kotlin Spring Boot), ai(Python FastAPI), mcp(TypeScript) 4개 앱 Dockerfile 작성
- 전 앱 멀티 스테이지 빌드로 이미지 경량화
- 비루트 유저 실행 적용

## Details
| 앱 | 베이스 이미지 | 빌드 도구 |
|----|-------------|----------|
| web | node:22-alpine | bun |
| api | eclipse-temurin:21-jre-alpine | Gradle |
| ai | python:3.12-slim | uv |
| mcp | oven/bun:1-slim | bun |

## Test plan
- [ ] 각 앱 구현 후 `docker build` 정상 빌드 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)