### PR TITLE
chore: docker-compose 로컬 개발 환경 구성 (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# ── 로컬 docker-compose 기본값 (실제 값은 .env.local에 작성) ──────────────
+
+# PostgreSQL
+POSTGRES_DB=grovarc
+POSTGRES_USER=grovarc
+POSTGRES_PASSWORD=grovarc
+
+# MongoDB
+MONGO_INITDB_ROOT_USERNAME=grovarc
+MONGO_INITDB_ROOT_PASSWORD=grovarc
+
+# API Keys
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Auth
+JWT_SECRET=
+
+# AWS
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=ap-northeast-2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,138 @@
+services:
+
+  # ── PostgreSQL + pgvector ──────────────────────────────────────────────────
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: grovarc-postgres
+    environment:
+      POSTGRES_DB: grovarc
+      POSTGRES_USER: grovarc
+      POSTGRES_PASSWORD: grovarc
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U grovarc"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Redis ──────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: grovarc-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── MongoDB ────────────────────────────────────────────────────────────────
+  mongodb:
+    image: mongo:7
+    container_name: grovarc-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: grovarc
+      MONGO_INITDB_ROOT_PASSWORD: grovarc
+      MONGO_INITDB_DATABASE: grovarc
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Zookeeper (Kafka 의존) ─────────────────────────────────────────────────
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.7.0
+    container_name: grovarc-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      - zookeeper_data:/var/lib/zookeeper/data
+      - zookeeper_log:/var/lib/zookeeper/log
+
+  # ── Kafka ──────────────────────────────────────────────────────────────────
+  kafka:
+    image: confluentinc/cp-kafka:7.7.0
+    container_name: grovarc-kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+
+  # ── 앱 서비스 (로컬 개발 시 주석 해제) ────────────────────────────────────
+  # api:
+  #   build: ./apps/api
+  #   container_name: grovarc-api
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #     redis:
+  #       condition: service_healthy
+  #     kafka:
+  #       condition: service_healthy
+  #   ports:
+  #     - "8080:8080"
+  #   environment:
+  #     SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/grovarc
+  #     SPRING_DATASOURCE_USERNAME: grovarc
+  #     SPRING_DATASOURCE_PASSWORD: grovarc
+  #     SPRING_REDIS_HOST: redis
+  #     KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+
+  # ai:
+  #   build: ./apps/ai
+  #   container_name: grovarc-ai
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #     mongodb:
+  #       condition: service_healthy
+  #     kafka:
+  #       condition: service_healthy
+  #   ports:
+  #     - "8000:8000"
+  #   environment:
+  #     DATABASE_URL: postgresql://grovarc:grovarc@postgres:5432/grovarc
+  #     MONGODB_URL: mongodb://grovarc:grovarc@mongodb:27017/grovarc
+  #     KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+
+  # web:
+  #   build: ./apps/web
+  #   container_name: grovarc-web
+  #   depends_on:
+  #     - api
+  #   ports:
+  #     - "3000:3000"
+
+volumes:
+  postgres_data:
+  redis_data:
+  mongodb_data:
+  zookeeper_data:
+  zookeeper_log:
+  kafka_data:


### PR DESCRIPTION
## Summary
- PostgreSQL(pgvector), Redis, MongoDB, Kafka, Zookeeper 로컬 환경 구성
- 각 서비스 healthcheck 적용으로 의존성 순서 보장
- 앱 서비스는 주석 처리 — 각 앱 구현 후 주석 해제하여 통합 테스트 사용

## Test plan
- [ ] `docker compose up -d` 정상 실행 확인
- [ ] 각 서비스 healthcheck 통과 확인

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)