### PR TITLE
chore: Kubernetes 매니페스트 작성 (#12)

### DIFF
--- a/infra/k8s/configmaps/ai-config.yaml
+++ b/infra/k8s/configmaps/ai-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ai-config
+  namespace: grovarc
+data:
+  APP_ENV: "prod"
+  PORT: "8000"
+  KAFKA_BOOTSTRAP_SERVERS: "kafka-service:9092"

--- a/infra/k8s/configmaps/api-config.yaml
+++ b/infra/k8s/configmaps/api-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-config
+  namespace: grovarc
+data:
+  SPRING_PROFILES_ACTIVE: "prod"
+  SERVER_PORT: "8080"
+  KAFKA_BOOTSTRAP_SERVERS: "kafka-service:9092"
+  SPRING_REDIS_HOST: "redis-service"
+  SPRING_REDIS_PORT: "6379"

--- a/infra/k8s/deployments/ai-deployment.yaml
+++ b/infra/k8s/deployments/ai-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai
+  namespace: grovarc
+  labels:
+    app: ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai
+  template:
+    metadata:
+      labels:
+        app: ai
+    spec:
+      containers:
+        - name: ai
+          image: <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/grovarc-ai:latest
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: ai-config
+            - secretRef:
+                name: grovarc-secrets
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1000m"
+              memory: "2Gi"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 40
+            periodSeconds: 20

--- a/infra/k8s/deployments/api-deployment.yaml
+++ b/infra/k8s/deployments/api-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: grovarc
+  labels:
+    app: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/grovarc-api:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: api-config
+            - secretRef:
+                name: grovarc-secrets
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20

--- a/infra/k8s/deployments/mcp-deployment.yaml
+++ b/infra/k8s/deployments/mcp-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp
+  namespace: grovarc
+  labels:
+    app: mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp
+  template:
+    metadata:
+      labels:
+        app: mcp
+    spec:
+      containers:
+        - name: mcp
+          image: <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/grovarc-mcp:latest
+          ports:
+            - containerPort: 3001
+          env:
+            - name: API_URL
+              value: "http://api-service:8080"
+          envFrom:
+            - secretRef:
+                name: grovarc-secrets
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"

--- a/infra/k8s/deployments/web-deployment.yaml
+++ b/infra/k8s/deployments/web-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: grovarc
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/grovarc-web:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NEXT_PUBLIC_API_URL
+              value: "https://api.grovarc.dev"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "300m"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/infra/k8s/hpa/hpa.yaml
+++ b/infra/k8s/hpa/hpa.yaml
@@ -1,0 +1,39 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: grovarc
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-hpa
+  namespace: grovarc
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infra/k8s/ingress/ingress.yaml
+++ b/infra/k8s/ingress/ingress.yaml
@@ -1,0 +1,44 @@
+# AWS Load Balancer Controller 사용 (EKS)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grovarc-ingress
+  namespace: grovarc
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/certificate-arn: <ACM_CERTIFICATE_ARN>
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+spec:
+  rules:
+    - host: grovarc.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-service
+                port:
+                  number: 3000
+    - host: api.grovarc.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 8080
+    - host: mcp.grovarc.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-service
+                port:
+                  number: 3001

--- a/infra/k8s/namespaces/namespace.yaml
+++ b/infra/k8s/namespaces/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grovarc
+  labels:
+    app.kubernetes.io/managed-by: kubectl

--- a/infra/k8s/services/services.yaml
+++ b/infra/k8s/services/services.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: grovarc
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-service
+  namespace: grovarc
+spec:
+  selector:
+    app: ai
+  ports:
+    - port: 8000
+      targetPort: 8000
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-service
+  namespace: grovarc
+spec:
+  selector:
+    app: web
+  ports:
+    - port: 3000
+      targetPort: 3000
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-service
+  namespace: grovarc
+spec:
+  selector:
+    app: mcp
+  ports:
+    - port: 3001
+      targetPort: 3001
+  type: ClusterIP


### PR DESCRIPTION
## Summary
EKS 배포를 위한 Kubernetes 매니페스트 전체 구성

## 구성
| 디렉토리 | 내용 |
|----------|------|
| namespaces | grovarc 네임스페이스 |
| configmaps | api, ai 환경변수 |
| secrets | 시크릿 템플릿 (실제 값 미포함) |
| deployments | api, ai, web, mcp Deployment |
| services | 4개 앱 ClusterIP Service |
| ingress | ALB Ingress (3개 도메인) |
| hpa | api, web HPA (CPU 70%) |

## 주의사항
- `secrets.yaml`은 템플릿이며 실제 배포 시 AWS Secrets Manager + External Secrets Operator 사용 권장
- Deployment의 `<AWS_ACCOUNT_ID>`, Ingress의 `<ACM_CERTIFICATE_ARN>` 배포 전 교체 필요

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)