### PR TITLE
chore: Prometheus + Grafana 모니터링 설정 (#13)

### DIFF
--- a/infra/k8s/monitoring/grovarc-dashboards-configmap.yaml
+++ b/infra/k8s/monitoring/grovarc-dashboards-configmap.yaml
@@ -1,0 +1,83 @@
+# 이 파일은 아래 명령으로 생성하세요 (배포 시 1회):
+#
+# kubectl create configmap grovarc-dashboards \
+#   --from-file=grovarc-overview.json=infra/monitoring/grafana/dashboards/grovarc-overview.json \
+#   -n monitoring
+#
+# 또는 아래 매니페스트를 직접 apply:
+# kubectl apply -f infra/k8s/monitoring/grovarc-dashboards-configmap.yaml
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grovarc-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  grovarc-overview.json: |
+    {
+      "title": "Grovarc Overview",
+      "uid": "grovarc-overview",
+      "tags": ["grovarc"],
+      "timezone": "Asia/Seoul",
+      "panels": [
+        {
+          "id": 1,
+          "title": "API 요청 수 (RPS)",
+          "type": "timeseries",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count[1m])) by (uri)", "legendFormat": "{{ uri }}" }]
+        },
+        {
+          "id": 2,
+          "title": "API p95 응답시간 (ms)",
+          "type": "timeseries",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "targets": [
+            { "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "p95" },
+            { "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "p99" }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "API 5xx 에러율",
+          "type": "timeseries",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))", "legendFormat": "에러율" }]
+        },
+        {
+          "id": 4,
+          "title": "Pod 가용 현황",
+          "type": "stat",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "targets": [{ "expr": "kube_deployment_status_replicas_available{namespace=\"grovarc\"}", "legendFormat": "{{ deployment }}" }]
+        },
+        {
+          "id": 5,
+          "title": "JVM Heap 사용량",
+          "type": "timeseries",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "targets": [
+            { "expr": "jvm_memory_used_bytes{area=\"heap\"}", "legendFormat": "Heap Used" },
+            { "expr": "jvm_memory_max_bytes{area=\"heap\"}", "legendFormat": "Heap Max" }
+          ]
+        },
+        {
+          "id": 6,
+          "title": "AI 서버 요청 수",
+          "type": "timeseries",
+          "datasource": "Prometheus",
+          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "targets": [{ "expr": "sum(rate(http_requests_total{job=\"grovarc-ai\"}[1m])) by (endpoint)", "legendFormat": "{{ endpoint }}" }]
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 38,
+      "version": 1
+    }

--- a/infra/k8s/monitoring/kube-prometheus-stack.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack.yaml
@@ -1,0 +1,60 @@
+# Helm으로 배포 — 아래는 values 오버라이드 파일입니다.
+# 배포 명령:
+#   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#   helm upgrade --install kube-prometheus-stack \
+#     prometheus-community/kube-prometheus-stack \
+#     -n monitoring --create-namespace \
+#     -f infra/k8s/monitoring/kube-prometheus-stack.yaml
+
+prometheus:
+  prometheusSpec:
+    retention: 15d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          resources:
+            requests:
+              storage: 20Gi
+    additionalScrapeConfigs:
+      - job_name: grovarc-api
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["api-service.grovarc.svc.cluster.local:8080"]
+      - job_name: grovarc-ai
+        metrics_path: /metrics
+        static_configs:
+          - targets: ["ai-service.grovarc.svc.cluster.local:8000"]
+
+grafana:
+  adminPassword: "change-me-on-install"
+  persistence:
+    enabled: true
+    size: 5Gi
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: grovarc
+          folder: Grovarc
+          type: file
+          options:
+            path: /var/lib/grafana/dashboards/grovarc
+  dashboardsConfigMaps:
+    grovarc: "grovarc-dashboards"
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: alb
+    hosts:
+      - grafana.grovarc.dev
+
+alertmanager:
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          resources:
+            requests:
+              storage: 2Gi

--- a/infra/k8s/monitoring/kube-prometheus-stack.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack.yaml
@@ -44,8 +44,7 @@ grafana:
     grovarc: "grovarc-dashboards"
   ingress:
     enabled: true
-    annotations:
-      kubernetes.io/ingress.class: alb
+    ingressClassName: alb
     hosts:
       - grafana.grovarc.dev
 

--- a/infra/monitoring/alertmanager/alertmanager.yml
+++ b/infra/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,28 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: default
+  routes:
+    - match:
+        severity: critical
+      receiver: critical-receiver
+      repeat_interval: 1h
+
+receivers:
+  - name: default
+    # 추후 Slack / 이메일 설정 추가
+
+  - name: critical-receiver
+    # 추후 PagerDuty / Slack 크리티컬 채널 설정 추가
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ["alertname"]

--- a/infra/monitoring/grafana/dashboards/grovarc-overview.json
+++ b/infra/monitoring/grafana/dashboards/grovarc-overview.json
@@ -1,0 +1,91 @@
+{
+  "title": "Grovarc Overview",
+  "uid": "grovarc-overview",
+  "tags": ["grovarc"],
+  "timezone": "Asia/Seoul",
+  "panels": [
+    {
+      "id": 1,
+      "title": "API 요청 수 (RPS)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count[1m])) by (uri)",
+          "legendFormat": "{{ uri }}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "API p95 응답시간 (ms)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "API 5xx 에러율",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))",
+          "legendFormat": "에러율"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Pod 가용 현황",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "kube_deployment_status_replicas_available{namespace=\"grovarc\"}",
+          "legendFormat": "{{ deployment }}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "JVM Heap 사용량",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "Heap Used"
+        },
+        {
+          "expr": "jvm_memory_max_bytes{area=\"heap\"}",
+          "legendFormat": "Heap Max"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "AI 서버 요청 수",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"grovarc-ai\"}[1m])) by (endpoint)",
+          "legendFormat": "{{ endpoint }}"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "version": 1
+}

--- a/infra/monitoring/prometheus/prometheus.yml
+++ b/infra/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,47 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - "rules/*.yml"
+
+scrape_configs:
+  # ── Prometheus 자체 ────────────────────────────────────────────────────────
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # ── Spring Boot API (Actuator) ─────────────────────────────────────────────
+  - job_name: grovarc-api
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["api-service:8080"]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+
+  # ── FastAPI AI 서버 ────────────────────────────────────────────────────────
+  - job_name: grovarc-ai
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["ai-service:8000"]
+
+  # ── Node Exporter (시스템 메트릭) ──────────────────────────────────────────
+  - job_name: node-exporter
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: "(.*):10250"
+        replacement: "${1}:9100"
+        target_label: __address__
+
+  # ── kube-state-metrics ─────────────────────────────────────────────────────
+  - job_name: kube-state-metrics
+    static_configs:
+      - targets: ["kube-state-metrics:8080"]

--- a/infra/monitoring/prometheus/rules/api-alerts.yml
+++ b/infra/monitoring/prometheus/rules/api-alerts.yml
@@ -1,0 +1,34 @@
+groups:
+  - name: grovarc-api
+    rules:
+      - alert: APIHighErrorRate
+        expr: |
+          sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+          /
+          sum(rate(http_server_requests_seconds_count[5m])) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API 5xx 에러율 5% 초과"
+          description: "{{ $value | humanizePercentage }} 에러율 발생 중"
+
+      - alert: APIHighLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_server_requests_seconds_bucket[5m])) by (le)
+          ) > 1.0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API p95 응답시간 1초 초과"
+          description: "p95 응답시간: {{ $value }}s"
+
+      - alert: APIPodDown
+        expr: kube_deployment_status_replicas_available{deployment="api"} < 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API Pod 가용 인스턴스 없음"


### PR DESCRIPTION
## Summary
- kube-prometheus-stack 기반 모니터링 스택 구성
- Grovarc 서비스 전용 알럿 룰 및 Grafana 대시보드 추가

## 구성
| 파일 | 내용 |
|------|------|
| prometheus.yml | api, ai, node-exporter, kube-state-metrics 수집 |
| rules/api-alerts.yml | 5xx 에러율 / p95 응답시간 / Pod 다운 알럿 |
| alertmanager.yml | 심각도별 라우팅 (critical / warning) |
| grafana/dashboards | RPS, 응답시간, 에러율, JVM, AI 서버 패널 |
| k8s/monitoring | Helm values 오버라이드 (Prometheus, Grafana, Alertmanager) |

## 배포 방법
```bash
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm upgrade --install kube-prometheus-stack \
  prometheus-community/kube-prometheus-stack \
  -n monitoring --create-namespace \
  -f infra/k8s/monitoring/kube-prometheus-stack.yaml
```

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)