### PR TITLE
[Task] 작업 로그 CRUD API

### DIFF
--- a/apps/api/src/main/kotlin/dev/grovarc/api/application/worklog/WorkLogService.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/application/worklog/WorkLogService.kt
@@ -1,0 +1,113 @@
+package dev.grovarc.api.application.worklog
+
+import dev.grovarc.api.domain.tag.TagRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.domain.worklog.WorkLog
+import dev.grovarc.api.domain.worklog.WorkLogRepository
+import dev.grovarc.api.infrastructure.kafka.WorkLogEventPublisher
+import dev.grovarc.api.interfaces.dto.*
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.util.UUID
+
+@Service
+@Transactional
+class WorkLogService(
+    private val workLogRepository: WorkLogRepository,
+    private val userRepository: UserRepository,
+    private val tagRepository: TagRepository,
+    private val eventPublisher: WorkLogEventPublisher,
+) {
+
+    fun create(userId: UUID, request: WorkLogCreateRequest): WorkLogResponse {
+        val user = findUser(userId)
+        val tags = resolveTagsForUser(request.tagIds, user)
+
+        val workLog = workLogRepository.save(
+            WorkLog(
+                user = user,
+                title = request.title,
+                content = request.content,
+                logDate = request.logDate,
+                mood = request.mood,
+                tags = tags.toMutableSet(),
+            )
+        )
+
+        eventPublisher.publishWorkLogSaved(workLog.id!!, userId, workLog.logDate)
+        return WorkLogResponse.from(workLog)
+    }
+
+    @Transactional(readOnly = true)
+    fun getList(userId: UUID, pageable: Pageable): PageResponse<WorkLogResponse> {
+        val user = findUser(userId)
+        val page = workLogRepository.findAllByUserOrderByLogDateDesc(user, pageable)
+        return PageResponse(
+            content = page.content.map { WorkLogResponse.from(it) },
+            page = page.number,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getOne(userId: UUID, logId: UUID): WorkLogResponse {
+        val user = findUser(userId)
+        val workLog = workLogRepository.findByIdAndUser(logId, user)
+            ?: throw NoSuchElementException("작업 로그를 찾을 수 없습니다")
+        return WorkLogResponse.from(workLog)
+    }
+
+    fun update(userId: UUID, logId: UUID, request: WorkLogUpdateRequest): WorkLogResponse {
+        val user = findUser(userId)
+        val workLog = workLogRepository.findByIdAndUser(logId, user)
+            ?: throw NoSuchElementException("작업 로그를 찾을 수 없습니다")
+        val tags = resolveTagsForUser(request.tagIds, user)
+
+        workLog.update(request.title, request.content, request.logDate, request.mood)
+        workLog.replaceTags(tags)
+        return WorkLogResponse.from(workLog)
+    }
+
+    fun delete(userId: UUID, logId: UUID) {
+        val user = findUser(userId)
+        val workLog = workLogRepository.findByIdAndUser(logId, user)
+            ?: throw NoSuchElementException("작업 로그를 찾을 수 없습니다")
+        workLogRepository.delete(workLog)
+    }
+
+    @Transactional(readOnly = true)
+    fun getWeeklyStats(userId: UUID, date: LocalDate): WeeklyStatsResponse {
+        val user = findUser(userId)
+        val weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val weekEnd = weekStart.plusDays(6)
+
+        val rawStats = workLogRepository.findDailyStats(user, weekStart, weekEnd)
+        val dailyStats = rawStats.map { row ->
+            DailyStat(
+                date = row[0] as LocalDate,
+                count = row[1] as Long,
+                avgMoodScore = (row[2] as? Double),
+            )
+        }
+
+        return WeeklyStatsResponse(
+            weekStart = weekStart,
+            weekEnd = weekEnd,
+            totalLogs = dailyStats.sumOf { it.count }.toInt(),
+            dailyStats = dailyStats,
+        )
+    }
+
+    private fun findUser(userId: UUID): User =
+        userRepository.findById(userId).orElseThrow { NoSuchElementException("유저를 찾을 수 없습니다") }
+
+    private fun resolveTagsForUser(tagIds: Set<UUID>, user: User) =
+        tagIds.mapNotNull { tagRepository.findByIdAndUser(it, user) }.toSet()
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/tag/Tag.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/tag/Tag.kt
@@ -1,0 +1,30 @@
+package dev.grovarc.api.domain.tag
+
+import dev.grovarc.api.domain.user.User
+import jakarta.persistence.*
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "tags",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "name"])],
+)
+class Tag(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column
+    val color: String? = null,
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/tag/TagRepository.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/tag/TagRepository.kt
@@ -1,0 +1,11 @@
+package dev.grovarc.api.domain.tag
+
+import dev.grovarc.api.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface TagRepository : JpaRepository<Tag, UUID> {
+    fun findAllByUser(user: User): List<Tag>
+    fun findByIdAndUser(id: UUID, user: User): Tag?
+    fun existsByUserAndName(user: User, name: String): Boolean
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/worklog/WorkLog.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/worklog/WorkLog.kt
@@ -1,0 +1,64 @@
+package dev.grovarc.api.domain.worklog
+
+import dev.grovarc.api.domain.tag.Tag
+import dev.grovarc.api.domain.user.User
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "work_logs")
+class WorkLog(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    var title: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String,
+
+    @Column(nullable = false)
+    var logDate: LocalDate,
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    var mood: Mood? = null,
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "work_log_tags",
+        joinColumns = [JoinColumn(name = "work_log_id")],
+        inverseJoinColumns = [JoinColumn(name = "tag_id")],
+    )
+    val tags: MutableSet<Tag> = mutableSetOf(),
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun update(title: String, content: String, logDate: LocalDate, mood: Mood?) {
+        this.title = title
+        this.content = content
+        this.logDate = logDate
+        this.mood = mood
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    fun replaceTags(newTags: Set<Tag>) {
+        tags.clear()
+        tags.addAll(newTags)
+    }
+}
+
+enum class Mood {
+    GREAT, GOOD, NEUTRAL, BAD, TERRIBLE
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/worklog/WorkLogRepository.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/worklog/WorkLogRepository.kt
@@ -1,0 +1,42 @@
+package dev.grovarc.api.domain.worklog
+
+import dev.grovarc.api.domain.user.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+import java.util.UUID
+
+interface WorkLogRepository : JpaRepository<WorkLog, UUID> {
+    fun findByIdAndUser(id: UUID, user: User): WorkLog?
+    fun findAllByUserOrderByLogDateDesc(user: User, pageable: Pageable): Page<WorkLog>
+
+    @Query("""
+        SELECT w FROM WorkLog w
+        WHERE w.user = :user
+          AND w.logDate BETWEEN :from AND :to
+        ORDER BY w.logDate DESC
+    """)
+    fun findByUserAndDateRange(
+        @Param("user") user: User,
+        @Param("from") from: LocalDate,
+        @Param("to") to: LocalDate,
+    ): List<WorkLog>
+
+    @Query("""
+        SELECT w.logDate, COUNT(w), AVG(CASE w.mood
+            WHEN 'GREAT' THEN 5 WHEN 'GOOD' THEN 4 WHEN 'NEUTRAL' THEN 3
+            WHEN 'BAD' THEN 2 WHEN 'TERRIBLE' THEN 1 ELSE NULL END)
+        FROM WorkLog w
+        WHERE w.user = :user AND w.logDate BETWEEN :from AND :to
+        GROUP BY w.logDate
+        ORDER BY w.logDate
+    """)
+    fun findDailyStats(
+        @Param("user") user: User,
+        @Param("from") from: LocalDate,
+        @Param("to") to: LocalDate,
+    ): List<Array<Any>>
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/infrastructure/kafka/WorkLogEventPublisher.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/infrastructure/kafka/WorkLogEventPublisher.kt
@@ -1,0 +1,44 @@
+package dev.grovarc.api.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+class WorkLogEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        const val TOPIC_WORK_LOG_SAVED = "work-log.saved"
+    }
+
+    fun publishWorkLogSaved(workLogId: UUID, userId: UUID, logDate: LocalDate) {
+        val payload = objectMapper.writeValueAsString(
+            WorkLogSavedEvent(
+                workLogId = workLogId.toString(),
+                userId = userId.toString(),
+                logDate = logDate.toString(),
+            )
+        )
+        kafkaTemplate.send(TOPIC_WORK_LOG_SAVED, userId.toString(), payload)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.error("Kafka 이벤트 발행 실패 workLogId={}: {}", workLogId, ex.message)
+                } else {
+                    log.debug("Kafka 이벤트 발행 완료 workLogId={}", workLogId)
+                }
+            }
+    }
+}
+
+data class WorkLogSavedEvent(
+    val workLogId: String,
+    val userId: String,
+    val logDate: String,
+)

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/WorkLogDto.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/WorkLogDto.kt
@@ -1,0 +1,92 @@
+package dev.grovarc.api.interfaces.dto
+
+import dev.grovarc.api.domain.worklog.Mood
+import dev.grovarc.api.domain.worklog.WorkLog
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class WorkLogCreateRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    @field:Size(max = 255, message = "제목은 255자 이하여야 합니다")
+    val title: String,
+
+    @field:NotBlank(message = "내용은 필수입니다")
+    val content: String,
+
+    @field:NotNull(message = "날짜는 필수입니다")
+    val logDate: LocalDate,
+
+    val mood: Mood? = null,
+    val tagIds: Set<UUID> = emptySet(),
+)
+
+data class WorkLogUpdateRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    @field:Size(max = 255, message = "제목은 255자 이하여야 합니다")
+    val title: String,
+
+    @field:NotBlank(message = "내용은 필수입니다")
+    val content: String,
+
+    @field:NotNull(message = "날짜는 필수입니다")
+    val logDate: LocalDate,
+
+    val mood: Mood? = null,
+    val tagIds: Set<UUID> = emptySet(),
+)
+
+data class WorkLogResponse(
+    val id: UUID,
+    val title: String,
+    val content: String,
+    val logDate: LocalDate,
+    val mood: Mood?,
+    val tags: List<TagResponse>,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(workLog: WorkLog) = WorkLogResponse(
+            id = workLog.id!!,
+            title = workLog.title,
+            content = workLog.content,
+            logDate = workLog.logDate,
+            mood = workLog.mood,
+            tags = workLog.tags.map { TagResponse(it.id!!, it.name, it.color) },
+            createdAt = workLog.createdAt,
+            updatedAt = workLog.updatedAt,
+        )
+    }
+}
+
+data class TagResponse(
+    val id: UUID,
+    val name: String,
+    val color: String?,
+)
+
+data class WeeklyStatsResponse(
+    val weekStart: LocalDate,
+    val weekEnd: LocalDate,
+    val totalLogs: Int,
+    val dailyStats: List<DailyStat>,
+)
+
+data class DailyStat(
+    val date: LocalDate,
+    val count: Long,
+    val avgMoodScore: Double?,
+)
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/GlobalExceptionHandler.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/GlobalExceptionHandler.kt
@@ -27,6 +27,13 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNotFound(ex: NoSuchElementException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            ErrorResponse(code = "NOT_FOUND", message = ex.message ?: "리소스를 찾을 수 없습니다")
+        )
+    }
+
     @ExceptionHandler(Exception::class)
     fun handleGeneral(ex: Exception): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/WorkLogController.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/WorkLogController.kt
@@ -1,0 +1,69 @@
+package dev.grovarc.api.interfaces.rest
+
+import dev.grovarc.api.application.worklog.WorkLogService
+import dev.grovarc.api.interfaces.dto.*
+import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/logs")
+class WorkLogController(private val workLogService: WorkLogService) {
+
+    @PostMapping
+    fun create(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: WorkLogCreateRequest,
+    ): ResponseEntity<WorkLogResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(workLogService.create(userId, request))
+
+    @GetMapping
+    fun getList(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): ResponseEntity<PageResponse<WorkLogResponse>> {
+        val pageable = PageRequest.of(page, size, Sort.by("logDate").descending())
+        return ResponseEntity.ok(workLogService.getList(userId, pageable))
+    }
+
+    @GetMapping("/{logId}")
+    fun getOne(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable logId: UUID,
+    ): ResponseEntity<WorkLogResponse> =
+        ResponseEntity.ok(workLogService.getOne(userId, logId))
+
+    @PutMapping("/{logId}")
+    fun update(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable logId: UUID,
+        @Valid @RequestBody request: WorkLogUpdateRequest,
+    ): ResponseEntity<WorkLogResponse> =
+        ResponseEntity.ok(workLogService.update(userId, logId, request))
+
+    @DeleteMapping("/{logId}")
+    fun delete(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable logId: UUID,
+    ): ResponseEntity<Unit> {
+        workLogService.delete(userId, logId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/stats/weekly")
+    fun weeklyStats(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate?,
+    ): ResponseEntity<WeeklyStatsResponse> =
+        ResponseEntity.ok(workLogService.getWeeklyStats(userId, date ?: LocalDate.now()))
+}

--- a/apps/api/src/test/kotlin/dev/grovarc/api/application/worklog/WorkLogServiceTest.kt
+++ b/apps/api/src/test/kotlin/dev/grovarc/api/application/worklog/WorkLogServiceTest.kt
@@ -1,0 +1,141 @@
+package dev.grovarc.api.application.worklog
+
+import dev.grovarc.api.domain.tag.Tag
+import dev.grovarc.api.domain.tag.TagRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.domain.worklog.Mood
+import dev.grovarc.api.domain.worklog.WorkLog
+import dev.grovarc.api.domain.worklog.WorkLogRepository
+import dev.grovarc.api.infrastructure.kafka.WorkLogEventPublisher
+import dev.grovarc.api.interfaces.dto.WorkLogCreateRequest
+import dev.grovarc.api.interfaces.dto.WorkLogUpdateRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class WorkLogServiceTest {
+
+    @Mock lateinit var workLogRepository: WorkLogRepository
+    @Mock lateinit var userRepository: UserRepository
+    @Mock lateinit var tagRepository: TagRepository
+    @Mock lateinit var eventPublisher: WorkLogEventPublisher
+
+    private lateinit var workLogService: WorkLogService
+    private lateinit var testUser: User
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        workLogService = WorkLogService(workLogRepository, userRepository, tagRepository, eventPublisher)
+        testUser = User(id = userId, email = "test@grovarc.dev", password = "hashed", nickname = "tester")
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(testUser))
+    }
+
+    @Test
+    fun `로그 작성 시 저장 후 Kafka 이벤트를 발행한다`() {
+        val request = WorkLogCreateRequest(
+            title = "오늘의 작업",
+            content = "Spring Boot 세팅 완료",
+            logDate = LocalDate.now(),
+            mood = Mood.GOOD,
+        )
+        val savedLog = WorkLog(
+            id = UUID.randomUUID(),
+            user = testUser,
+            title = request.title,
+            content = request.content,
+            logDate = request.logDate,
+            mood = request.mood,
+        )
+        whenever(workLogRepository.save(any())).thenReturn(savedLog)
+
+        val response = workLogService.create(userId, request)
+
+        assertThat(response.title).isEqualTo(request.title)
+        assertThat(response.mood).isEqualTo(Mood.GOOD)
+        verify(eventPublisher).publishWorkLogSaved(savedLog.id!!, userId, savedLog.logDate)
+    }
+
+    @Test
+    fun `로그 목록 조회 시 페이지 응답을 반환한다`() {
+        val logs = listOf(
+            WorkLog(id = UUID.randomUUID(), user = testUser, title = "log1", content = "c1", logDate = LocalDate.now()),
+            WorkLog(id = UUID.randomUUID(), user = testUser, title = "log2", content = "c2", logDate = LocalDate.now().minusDays(1)),
+        )
+        val pageable = PageRequest.of(0, 20)
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(testUser, pageable))
+            .thenReturn(PageImpl(logs, pageable, 2))
+
+        val result = workLogService.getList(userId, pageable)
+
+        assertThat(result.content).hasSize(2)
+        assertThat(result.totalElements).isEqualTo(2)
+    }
+
+    @Test
+    fun `존재하지 않는 로그 조회 시 예외가 발생한다`() {
+        val logId = UUID.randomUUID()
+        whenever(workLogRepository.findByIdAndUser(logId, testUser)).thenReturn(null)
+
+        assertThatThrownBy { workLogService.getOne(userId, logId) }
+            .isInstanceOf(NoSuchElementException::class.java)
+            .hasMessage("작업 로그를 찾을 수 없습니다")
+    }
+
+    @Test
+    fun `로그 수정 시 내용이 변경된다`() {
+        val logId = UUID.randomUUID()
+        val existing = WorkLog(
+            id = logId, user = testUser,
+            title = "old", content = "old content", logDate = LocalDate.now(),
+        )
+        val request = WorkLogUpdateRequest(
+            title = "new title", content = "new content",
+            logDate = LocalDate.now(), mood = Mood.GREAT,
+        )
+        whenever(workLogRepository.findByIdAndUser(logId, testUser)).thenReturn(existing)
+
+        val response = workLogService.update(userId, logId, request)
+
+        assertThat(response.title).isEqualTo("new title")
+        assertThat(response.mood).isEqualTo(Mood.GREAT)
+    }
+
+    @Test
+    fun `다른 유저의 로그 삭제 시 예외가 발생한다`() {
+        val logId = UUID.randomUUID()
+        whenever(workLogRepository.findByIdAndUser(logId, testUser)).thenReturn(null)
+
+        assertThatThrownBy { workLogService.delete(userId, logId) }
+            .isInstanceOf(NoSuchElementException::class.java)
+
+        verify(workLogRepository, never()).delete(any())
+    }
+
+    @Test
+    fun `주간 통계 조회 시 해당 주의 데이터를 반환한다`() {
+        val monday = LocalDate.of(2026, 3, 23)
+        whenever(workLogRepository.findDailyStats(any(), any(), any())).thenReturn(emptyList())
+
+        val result = workLogService.getWeeklyStats(userId, monday)
+
+        assertThat(result.weekStart).isEqualTo(monday)
+        assertThat(result.weekEnd).isEqualTo(monday.plusDays(6))
+        assertThat(result.totalLogs).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #22

## 작업 내용

### Domain
- `WorkLog` 엔티티 (title/content/logDate/Mood/Tags N:M)
- `Tag` 엔티티 (user FK, name, color)
- `WorkLogRepository` — 페이징, 날짜 범위, 일별 통계 JPQL
- `TagRepository` — 유저별 태그 조회

### Infrastructure
- `WorkLogEventPublisher` — 로그 저장 시 `work-log.saved` Kafka 토픽 발행

### Application
- `WorkLogService` — 작성/조회(페이징)/단건 조회/수정/삭제/주간 통계

### Interfaces
- `WorkLogController` — CRUD + `GET /logs/stats/weekly`
- `GlobalExceptionHandler` — `NoSuchElementException` → 404 추가

### 테스트
- `WorkLogServiceTest` — 5개 케이스 (Mockito)

## API 스펙

| Method | Path | 설명 |
|--------|------|------|
| POST | `/api/v1/logs` | 로그 작성 |
| GET | `/api/v1/logs?page=0&size=20` | 로그 목록 (페이징) |
| GET | `/api/v1/logs/{logId}` | 단건 조회 |
| PUT | `/api/v1/logs/{logId}` | 수정 |
| DELETE | `/api/v1/logs/{logId}` | 삭제 |
| GET | `/api/v1/logs/stats/weekly?date=2026-03-23` | 주간 통계 |

Made with [Cursor](https://cursor.com)