### PR TITLE
[Task] 태그 API

### DIFF
--- a/apps/api/src/main/kotlin/dev/grovarc/api/application/tag/TagService.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/application/tag/TagService.kt
@@ -1,0 +1,48 @@
+package dev.grovarc.api.application.tag
+
+import dev.grovarc.api.domain.tag.Tag
+import dev.grovarc.api.domain.tag.TagRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.interfaces.dto.TagCreateRequest
+import dev.grovarc.api.interfaces.dto.TagDetailResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional
+class TagService(
+    private val tagRepository: TagRepository,
+    private val userRepository: UserRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getAll(userId: UUID): List<TagDetailResponse> {
+        val user = findUser(userId)
+        return tagRepository.findAllByUser(user).map { TagDetailResponse.from(it) }
+    }
+
+    fun create(userId: UUID, request: TagCreateRequest): TagDetailResponse {
+        val user = findUser(userId)
+
+        if (tagRepository.existsByUserAndName(user, request.name)) {
+            throw IllegalArgumentException("이미 존재하는 태그 이름입니다: ${request.name}")
+        }
+
+        val tag = tagRepository.save(
+            Tag(user = user, name = request.name, color = request.color)
+        )
+        return TagDetailResponse.from(tag)
+    }
+
+    fun delete(userId: UUID, tagId: UUID) {
+        val user = findUser(userId)
+        val tag = tagRepository.findByIdAndUser(tagId, user)
+            ?: throw NoSuchElementException("태그를 찾을 수 없습니다")
+        tagRepository.delete(tag)
+    }
+
+    private fun findUser(userId: UUID): User =
+        userRepository.findById(userId).orElseThrow { NoSuchElementException("유저를 찾을 수 없습니다") }
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/TagDto.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/TagDto.kt
@@ -1,0 +1,33 @@
+package dev.grovarc.api.interfaces.dto
+
+import dev.grovarc.api.domain.tag.Tag
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class TagCreateRequest(
+    @field:NotBlank(message = "태그 이름은 필수입니다")
+    @field:Size(min = 1, max = 20, message = "태그 이름은 1~20자여야 합니다")
+    val name: String,
+
+    @field:Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "색상은 #RRGGBB 형식이어야 합니다")
+    val color: String? = null,
+)
+
+data class TagDetailResponse(
+    val id: UUID,
+    val name: String,
+    val color: String?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(tag: Tag) = TagDetailResponse(
+            id = tag.id!!,
+            name = tag.name,
+            color = tag.color,
+            createdAt = tag.createdAt,
+        )
+    }
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/TagController.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/TagController.kt
@@ -1,0 +1,38 @@
+package dev.grovarc.api.interfaces.rest
+
+import dev.grovarc.api.application.tag.TagService
+import dev.grovarc.api.interfaces.dto.TagCreateRequest
+import dev.grovarc.api.interfaces.dto.TagDetailResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/tags")
+class TagController(private val tagService: TagService) {
+
+    @GetMapping
+    fun getAll(
+        @AuthenticationPrincipal userId: UUID,
+    ): ResponseEntity<List<TagDetailResponse>> =
+        ResponseEntity.ok(tagService.getAll(userId))
+
+    @PostMapping
+    fun create(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: TagCreateRequest,
+    ): ResponseEntity<TagDetailResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(tagService.create(userId, request))
+
+    @DeleteMapping("/{tagId}")
+    fun delete(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tagId: UUID,
+    ): ResponseEntity<Unit> {
+        tagService.delete(userId, tagId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/apps/api/src/test/kotlin/dev/grovarc/api/application/tag/TagServiceTest.kt
+++ b/apps/api/src/test/kotlin/dev/grovarc/api/application/tag/TagServiceTest.kt
@@ -1,0 +1,101 @@
+package dev.grovarc.api.application.tag
+
+import dev.grovarc.api.domain.tag.Tag
+import dev.grovarc.api.domain.tag.TagRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.interfaces.dto.TagCreateRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class TagServiceTest {
+
+    @Mock lateinit var tagRepository: TagRepository
+    @Mock lateinit var userRepository: UserRepository
+
+    private lateinit var tagService: TagService
+    private lateinit var testUser: User
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        tagService = TagService(tagRepository, userRepository)
+        testUser = User(id = userId, email = "test@grovarc.dev", password = "hashed", nickname = "tester")
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(testUser))
+    }
+
+    @Test
+    fun `태그 목록 조회 시 유저의 태그를 반환한다`() {
+        val tags = listOf(
+            Tag(id = UUID.randomUUID(), user = testUser, name = "Kotlin", color = "#7F52FF"),
+            Tag(id = UUID.randomUUID(), user = testUser, name = "Spring", color = "#6DB33F"),
+        )
+        whenever(tagRepository.findAllByUser(testUser)).thenReturn(tags)
+
+        val result = tagService.getAll(userId)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.name }).containsExactly("Kotlin", "Spring")
+    }
+
+    @Test
+    fun `태그 생성 성공 시 생성된 태그를 반환한다`() {
+        val request = TagCreateRequest(name = "Kotlin", color = "#7F52FF")
+        val saved = Tag(id = UUID.randomUUID(), user = testUser, name = request.name, color = request.color)
+
+        whenever(tagRepository.existsByUserAndName(testUser, request.name)).thenReturn(false)
+        whenever(tagRepository.save(any())).thenReturn(saved)
+
+        val result = tagService.create(userId, request)
+
+        assertThat(result.name).isEqualTo("Kotlin")
+        assertThat(result.color).isEqualTo("#7F52FF")
+    }
+
+    @Test
+    fun `중복된 태그 이름으로 생성 시 예외가 발생한다`() {
+        val request = TagCreateRequest(name = "Kotlin")
+        whenever(tagRepository.existsByUserAndName(testUser, request.name)).thenReturn(true)
+
+        assertThatThrownBy { tagService.create(userId, request) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("이미 존재하는 태그 이름입니다")
+
+        verify(tagRepository, never()).save(any())
+    }
+
+    @Test
+    fun `태그 삭제 성공 시 삭제가 호출된다`() {
+        val tagId = UUID.randomUUID()
+        val tag = Tag(id = tagId, user = testUser, name = "Kotlin")
+        whenever(tagRepository.findByIdAndUser(tagId, testUser)).thenReturn(tag)
+
+        tagService.delete(userId, tagId)
+
+        verify(tagRepository).delete(tag)
+    }
+
+    @Test
+    fun `존재하지 않는 태그 삭제 시 예외가 발생한다`() {
+        val tagId = UUID.randomUUID()
+        whenever(tagRepository.findByIdAndUser(tagId, testUser)).thenReturn(null)
+
+        assertThatThrownBy { tagService.delete(userId, tagId) }
+            .isInstanceOf(NoSuchElementException::class.java)
+            .hasMessage("태그를 찾을 수 없습니다")
+
+        verify(tagRepository, never()).delete(any())
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #23

## 작업 내용

> Tag 엔티티 & DB 스키마는 #22(작업 로그 CRUD)에서 이미 구현 완료

### Application
- `TagService` — 유저별 태그 목록 조회 / 생성 (중복 이름 검사) / 삭제

### Interfaces
- `TagController` — GET · POST · DELETE `/api/v1/tags`
- `TagCreateRequest` (name 필수, color #RRGGBB 형식 검증)
- `TagDetailResponse`

### 테스트
- `TagServiceTest` — 5개 케이스 (Mockito)

## API 스펙

| Method | Path | 설명 |
|--------|------|------|
| GET | `/api/v1/tags` | 유저의 태그 목록 조회 |
| POST | `/api/v1/tags` | 태그 생성 |
| DELETE | `/api/v1/tags/{tagId}` | 태그 삭제 |

Made with [Cursor](https://cursor.com)