### PR TITLE
[Task] 회고 API

### DIFF
--- a/apps/api/src/main/kotlin/dev/grovarc/api/application/retrospective/RetrospectiveService.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/application/retrospective/RetrospectiveService.kt
@@ -1,0 +1,61 @@
+package dev.grovarc.api.application.retrospective
+
+import dev.grovarc.api.domain.retrospective.RetrospectiveRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.interfaces.dto.PageResponse
+import dev.grovarc.api.interfaces.dto.RetrospectiveResponse
+import dev.grovarc.api.interfaces.dto.RetrospectiveUpdateRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional
+class RetrospectiveService(
+    private val retrospectiveRepository: RetrospectiveRepository,
+    private val userRepository: UserRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getList(userId: UUID, pageable: Pageable): PageResponse<RetrospectiveResponse> {
+        val user = findUser(userId)
+        val page = retrospectiveRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)
+        return PageResponse(
+            content = page.content.map { RetrospectiveResponse.from(it) },
+            page = page.number,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getOne(userId: UUID, retroId: UUID): RetrospectiveResponse {
+        val user = findUser(userId)
+        val retro = findRetro(retroId, user)
+        return RetrospectiveResponse.from(retro)
+    }
+
+    fun update(userId: UUID, retroId: UUID, request: RetrospectiveUpdateRequest): RetrospectiveResponse {
+        val user = findUser(userId)
+        val retro = findRetro(retroId, user)
+        retro.update(request.title, request.content)
+        return RetrospectiveResponse.from(retro)
+    }
+
+    fun publish(userId: UUID, retroId: UUID): RetrospectiveResponse {
+        val user = findUser(userId)
+        val retro = findRetro(retroId, user)
+        retro.publish()
+        return RetrospectiveResponse.from(retro)
+    }
+
+    private fun findUser(userId: UUID): User =
+        userRepository.findById(userId).orElseThrow { NoSuchElementException("유저를 찾을 수 없습니다") }
+
+    private fun findRetro(retroId: UUID, user: User) =
+        retrospectiveRepository.findByIdAndUser(retroId, user)
+            ?: throw NoSuchElementException("회고를 찾을 수 없습니다")
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/retrospective/Retrospective.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/retrospective/Retrospective.kt
@@ -1,0 +1,56 @@
+package dev.grovarc.api.domain.retrospective
+
+import dev.grovarc.api.domain.user.User
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "retrospectives")
+class Retrospective(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    var title: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String,
+
+    @Column(nullable = false)
+    val periodFrom: LocalDate,
+
+    @Column(nullable = false)
+    val periodTo: LocalDate,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: RetrospectiveStatus = RetrospectiveStatus.DRAFT,
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun update(title: String, content: String) {
+        this.title = title
+        this.content = content
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    fun publish() {
+        this.status = RetrospectiveStatus.PUBLISHED
+        this.updatedAt = LocalDateTime.now()
+    }
+}
+
+enum class RetrospectiveStatus {
+    DRAFT, PUBLISHED
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/domain/retrospective/RetrospectiveRepository.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/domain/retrospective/RetrospectiveRepository.kt
@@ -1,0 +1,12 @@
+package dev.grovarc.api.domain.retrospective
+
+import dev.grovarc.api.domain.user.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface RetrospectiveRepository : JpaRepository<Retrospective, UUID> {
+    fun findByIdAndUser(id: UUID, user: User): Retrospective?
+    fun findAllByUserOrderByCreatedAtDesc(user: User, pageable: Pageable): Page<Retrospective>
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/RetrospectiveDto.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/RetrospectiveDto.kt
@@ -1,0 +1,40 @@
+package dev.grovarc.api.interfaces.dto
+
+import dev.grovarc.api.domain.retrospective.Retrospective
+import dev.grovarc.api.domain.retrospective.RetrospectiveStatus
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class RetrospectiveUpdateRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+
+    @field:NotBlank(message = "내용은 필수입니다")
+    val content: String,
+)
+
+data class RetrospectiveResponse(
+    val id: UUID,
+    val title: String,
+    val content: String,
+    val periodFrom: LocalDate,
+    val periodTo: LocalDate,
+    val status: RetrospectiveStatus,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(r: Retrospective) = RetrospectiveResponse(
+            id = r.id!!,
+            title = r.title,
+            content = r.content,
+            periodFrom = r.periodFrom,
+            periodTo = r.periodTo,
+            status = r.status,
+            createdAt = r.createdAt,
+            updatedAt = r.updatedAt,
+        )
+    }
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/RetrospectiveController.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/RetrospectiveController.kt
@@ -1,0 +1,50 @@
+package dev.grovarc.api.interfaces.rest
+
+import dev.grovarc.api.application.retrospective.RetrospectiveService
+import dev.grovarc.api.interfaces.dto.PageResponse
+import dev.grovarc.api.interfaces.dto.RetrospectiveResponse
+import dev.grovarc.api.interfaces.dto.RetrospectiveUpdateRequest
+import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/retrospectives")
+class RetrospectiveController(private val retrospectiveService: RetrospectiveService) {
+
+    @GetMapping
+    fun getList(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<PageResponse<RetrospectiveResponse>> {
+        val pageable = PageRequest.of(page, size, Sort.by("createdAt").descending())
+        return ResponseEntity.ok(retrospectiveService.getList(userId, pageable))
+    }
+
+    @GetMapping("/{retroId}")
+    fun getOne(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable retroId: UUID,
+    ): ResponseEntity<RetrospectiveResponse> =
+        ResponseEntity.ok(retrospectiveService.getOne(userId, retroId))
+
+    @PutMapping("/{retroId}")
+    fun update(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable retroId: UUID,
+        @Valid @RequestBody request: RetrospectiveUpdateRequest,
+    ): ResponseEntity<RetrospectiveResponse> =
+        ResponseEntity.ok(retrospectiveService.update(userId, retroId, request))
+
+    @PostMapping("/{retroId}/publish")
+    fun publish(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable retroId: UUID,
+    ): ResponseEntity<RetrospectiveResponse> =
+        ResponseEntity.ok(retrospectiveService.publish(userId, retroId))
+}

--- a/apps/api/src/test/kotlin/dev/grovarc/api/application/retrospective/RetrospectiveServiceTest.kt
+++ b/apps/api/src/test/kotlin/dev/grovarc/api/application/retrospective/RetrospectiveServiceTest.kt
@@ -1,0 +1,104 @@
+package dev.grovarc.api.application.retrospective
+
+import dev.grovarc.api.domain.retrospective.Retrospective
+import dev.grovarc.api.domain.retrospective.RetrospectiveRepository
+import dev.grovarc.api.domain.retrospective.RetrospectiveStatus
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.interfaces.dto.RetrospectiveUpdateRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class RetrospectiveServiceTest {
+
+    @Mock lateinit var retrospectiveRepository: RetrospectiveRepository
+    @Mock lateinit var userRepository: UserRepository
+
+    private lateinit var retrospectiveService: RetrospectiveService
+    private lateinit var testUser: User
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        retrospectiveService = RetrospectiveService(retrospectiveRepository, userRepository)
+        testUser = User(id = userId, email = "test@grovarc.dev", password = "hashed", nickname = "tester")
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(testUser))
+    }
+
+    private fun makeRetro(id: UUID = UUID.randomUUID()) = Retrospective(
+        id = id,
+        user = testUser,
+        title = "3월 4주차 회고",
+        content = "이번 주는 Spring Boot 세팅을 완료했다.",
+        periodFrom = LocalDate.of(2026, 3, 23),
+        periodTo = LocalDate.of(2026, 3, 29),
+    )
+
+    @Test
+    fun `회고 목록 조회 시 페이지 응답을 반환한다`() {
+        val retros = listOf(makeRetro(), makeRetro())
+        val pageable = PageRequest.of(0, 10)
+        whenever(retrospectiveRepository.findAllByUserOrderByCreatedAtDesc(testUser, pageable))
+            .thenReturn(PageImpl(retros, pageable, 2))
+
+        val result = retrospectiveService.getList(userId, pageable)
+
+        assertThat(result.content).hasSize(2)
+        assertThat(result.totalElements).isEqualTo(2)
+    }
+
+    @Test
+    fun `회고 단건 조회 성공 시 응답을 반환한다`() {
+        val retro = makeRetro()
+        whenever(retrospectiveRepository.findByIdAndUser(retro.id!!, testUser)).thenReturn(retro)
+
+        val result = retrospectiveService.getOne(userId, retro.id!!)
+
+        assertThat(result.title).isEqualTo(retro.title)
+        assertThat(result.status).isEqualTo(RetrospectiveStatus.DRAFT)
+    }
+
+    @Test
+    fun `존재하지 않는 회고 조회 시 예외가 발생한다`() {
+        val retroId = UUID.randomUUID()
+        whenever(retrospectiveRepository.findByIdAndUser(retroId, testUser)).thenReturn(null)
+
+        assertThatThrownBy { retrospectiveService.getOne(userId, retroId) }
+            .isInstanceOf(NoSuchElementException::class.java)
+            .hasMessage("회고를 찾을 수 없습니다")
+    }
+
+    @Test
+    fun `회고 수정 시 제목과 내용이 변경된다`() {
+        val retro = makeRetro()
+        whenever(retrospectiveRepository.findByIdAndUser(retro.id!!, testUser)).thenReturn(retro)
+        val request = RetrospectiveUpdateRequest(title = "수정된 제목", content = "수정된 내용")
+
+        val result = retrospectiveService.update(userId, retro.id!!, request)
+
+        assertThat(result.title).isEqualTo("수정된 제목")
+        assertThat(result.content).isEqualTo("수정된 내용")
+    }
+
+    @Test
+    fun `회고 발행 시 상태가 PUBLISHED로 변경된다`() {
+        val retro = makeRetro()
+        whenever(retrospectiveRepository.findByIdAndUser(retro.id!!, testUser)).thenReturn(retro)
+
+        val result = retrospectiveService.publish(userId, retro.id!!)
+
+        assertThat(result.status).isEqualTo(RetrospectiveStatus.PUBLISHED)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #24

## 작업 내용

### Domain
- `Retrospective` 엔티티 (title / content / periodFrom~To / status)
- `RetrospectiveStatus`: `DRAFT` → `PUBLISHED`
- `RetrospectiveRepository`: 유저별 페이징 목록, 단건 조회

### Application
- `RetrospectiveService`
  - 목록/단건 조회 (readOnly)
  - 수정 — 제목/내용 변경
  - 발행 — status를 `PUBLISHED`로 전환

### Interfaces
- `RetrospectiveController`
- `RetrospectiveUpdateRequest`, `RetrospectiveResponse` DTO

### 테스트
- `RetrospectiveServiceTest` — 5개 케이스 (Mockito)

## API 스펙

| Method | Path | 설명 |
|--------|------|------|
| GET | `/api/v1/retrospectives` | 회고 목록 (페이징) |
| GET | `/api/v1/retrospectives/{id}` | 단건 조회 |
| PUT | `/api/v1/retrospectives/{id}` | 수정 |
| POST | `/api/v1/retrospectives/{id}/publish` | 발행 (DRAFT → PUBLISHED) |

> 회고 **생성**은 AI Agent(Celery Beat)가 자동으로 수행 — Phase 3에서 구현

Made with [Cursor](https://cursor.com)