### PR TITLE
[Task] 대시보드 API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,11 +138,12 @@
 
 ```
 현재 Phase: 2 (진행 중)
-마지막 작업: #23 태그 API (PR #29)
-  - TagService: 목록 조회 / 생성 (중복 검사) / 삭제
-  - TagController: GET /POST /DELETE /api/v1/tags
-  - JUnit: TagServiceTest (5케이스)
-다음 할 일: #24 회고 API
+마지막 작업: #24 회고 API (PR #30)
+  - Retrospective 엔티티 (DRAFT/PUBLISHED 상태)
+  - RetrospectiveService: 목록/단건 조회, 수정, 발행
+  - RetrospectiveController: GET/PUT /retrospectives, POST /{id}/publish
+  - JUnit: RetrospectiveServiceTest (5케이스)
+다음 할 일: #25 대시보드 API
 블로커: -
 ```
 

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 dependencies {
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/apps/api/src/main/kotlin/dev/grovarc/api/application/dashboard/DashboardService.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/application/dashboard/DashboardService.kt
@@ -1,0 +1,104 @@
+package dev.grovarc.api.application.dashboard
+
+import dev.grovarc.api.domain.retrospective.RetrospectiveRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.domain.worklog.WorkLogRepository
+import dev.grovarc.api.infrastructure.cache.CacheConfig
+import dev.grovarc.api.interfaces.dto.*
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class DashboardService(
+    private val userRepository: UserRepository,
+    private val workLogRepository: WorkLogRepository,
+    private val retrospectiveRepository: RetrospectiveRepository,
+) {
+
+    @Cacheable(cacheNames = [CacheConfig.DASHBOARD], key = "#userId")
+    fun getDashboard(userId: UUID): DashboardResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { NoSuchElementException("유저를 찾을 수 없습니다") }
+
+        val today = LocalDate.now()
+        val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val monthStart = today.withDayOfMonth(1)
+
+        val allLogs = workLogRepository.findAllByUserOrderByLogDateDesc(user, PageRequest.of(0, Int.MAX_VALUE, Sort.by("logDate").descending()))
+        val totalLogs = allLogs.totalElements
+
+        val thisWeekLogs = workLogRepository.findByUserAndDateRange(user, weekStart, today).size
+        val thisMonthLogs = workLogRepository.findByUserAndDateRange(user, monthStart, today).size
+
+        val logDates = allLogs.content.map { it.logDate }.toSortedSet(compareByDescending { it })
+        val (currentStreak, longestStreak) = calculateStreaks(logDates, today)
+
+        val recentLogs = allLogs.content.take(5).map { log ->
+            WorkLogSummary(
+                id = log.id.toString(),
+                title = log.title,
+                logDate = log.logDate,
+                mood = log.mood?.name,
+                tagCount = log.tags.size,
+            )
+        }
+
+        val recentRetros = retrospectiveRepository
+            .findAllByUserOrderByCreatedAtDesc(user, PageRequest.of(0, 3))
+            .content.map { retro ->
+                RetrospectiveSummary(
+                    id = retro.id.toString(),
+                    title = retro.title,
+                    periodFrom = retro.periodFrom,
+                    periodTo = retro.periodTo,
+                    status = retro.status.name,
+                )
+            }
+
+        return DashboardResponse(
+            totalLogs = totalLogs,
+            currentStreak = currentStreak,
+            longestStreak = longestStreak,
+            thisWeekLogs = thisWeekLogs,
+            thisMonthLogs = thisMonthLogs,
+            recentLogs = recentLogs,
+            recentRetrospectives = recentRetros,
+        )
+    }
+
+    private fun calculateStreaks(dates: Set<LocalDate>, today: LocalDate): Pair<Int, Int> {
+        if (dates.isEmpty()) return Pair(0, 0)
+
+        val dateSet = dates.toHashSet()
+        var currentStreak = 0
+        var check = today
+        while (dateSet.contains(check)) {
+            currentStreak++
+            check = check.minusDays(1)
+        }
+
+        var longestStreak = 0
+        var streak = 1
+        val sorted = dates.sortedDescending()
+        for (i in 1 until sorted.size) {
+            if (sorted[i - 1].minusDays(1) == sorted[i]) {
+                streak++
+                if (streak > longestStreak) longestStreak = streak
+            } else {
+                streak = 1
+            }
+        }
+        longestStreak = maxOf(longestStreak, currentStreak, if (sorted.isNotEmpty()) 1 else 0)
+
+        return Pair(currentStreak, longestStreak)
+    }
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/infrastructure/cache/CacheConfig.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/infrastructure/cache/CacheConfig.kt
@@ -1,0 +1,42 @@
+package dev.grovarc.api.infrastructure.cache
+
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    companion object {
+        const val DASHBOARD = "dashboard"
+    }
+
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
+            )
+
+        val cacheConfigs = mapOf(
+            DASHBOARD to defaultConfig.entryTtl(Duration.ofMinutes(5))
+        )
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigs)
+            .build()
+    }
+}

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/DashboardDto.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/dto/DashboardDto.kt
@@ -1,0 +1,29 @@
+package dev.grovarc.api.interfaces.dto
+
+import java.time.LocalDate
+
+data class DashboardResponse(
+    val totalLogs: Long,
+    val currentStreak: Int,
+    val longestStreak: Int,
+    val thisWeekLogs: Int,
+    val thisMonthLogs: Int,
+    val recentLogs: List<WorkLogSummary>,
+    val recentRetrospectives: List<RetrospectiveSummary>,
+)
+
+data class WorkLogSummary(
+    val id: String,
+    val title: String,
+    val logDate: LocalDate,
+    val mood: String?,
+    val tagCount: Int,
+)
+
+data class RetrospectiveSummary(
+    val id: String,
+    val title: String,
+    val periodFrom: LocalDate,
+    val periodTo: LocalDate,
+    val status: String,
+)

--- a/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/DashboardController.kt
+++ b/apps/api/src/main/kotlin/dev/grovarc/api/interfaces/rest/DashboardController.kt
@@ -1,0 +1,21 @@
+package dev.grovarc.api.interfaces.rest
+
+import dev.grovarc.api.application.dashboard.DashboardService
+import dev.grovarc.api.interfaces.dto.DashboardResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/dashboard")
+class DashboardController(private val dashboardService: DashboardService) {
+
+    @GetMapping
+    fun getDashboard(
+        @AuthenticationPrincipal userId: UUID,
+    ): ResponseEntity<DashboardResponse> =
+        ResponseEntity.ok(dashboardService.getDashboard(userId))
+}

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -26,6 +26,14 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  cache:
+    type: redis
+    redis:
+      time-to-live: 300000  # 5분
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
@@ -81,6 +89,14 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  cache:
+    type: redis
+    redis:
+      time-to-live: 300000
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     consumer:

--- a/apps/api/src/test/kotlin/dev/grovarc/api/application/dashboard/DashboardServiceTest.kt
+++ b/apps/api/src/test/kotlin/dev/grovarc/api/application/dashboard/DashboardServiceTest.kt
@@ -1,0 +1,115 @@
+package dev.grovarc.api.application.dashboard
+
+import dev.grovarc.api.domain.retrospective.RetrospectiveRepository
+import dev.grovarc.api.domain.user.User
+import dev.grovarc.api.domain.user.UserRepository
+import dev.grovarc.api.domain.worklog.WorkLog
+import dev.grovarc.api.domain.worklog.WorkLogRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class DashboardServiceTest {
+
+    @Mock lateinit var userRepository: UserRepository
+    @Mock lateinit var workLogRepository: WorkLogRepository
+    @Mock lateinit var retrospectiveRepository: RetrospectiveRepository
+
+    private lateinit var dashboardService: DashboardService
+    private lateinit var testUser: User
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        dashboardService = DashboardService(userRepository, workLogRepository, retrospectiveRepository)
+        testUser = User(id = userId, email = "test@grovarc.dev", password = "hashed", nickname = "tester")
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(testUser))
+        whenever(retrospectiveRepository.findAllByUserOrderByCreatedAtDesc(any(), any()))
+            .thenReturn(PageImpl(emptyList()))
+    }
+
+    private fun makeLog(daysAgo: Long) = WorkLog(
+        id = UUID.randomUUID(), user = testUser,
+        title = "log", content = "content",
+        logDate = LocalDate.now().minusDays(daysAgo),
+    )
+
+    @Test
+    fun `로그가 없을 때 스트릭은 0이다`() {
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(any(), any()))
+            .thenReturn(PageImpl(emptyList()))
+        whenever(workLogRepository.findByUserAndDateRange(any(), any(), any()))
+            .thenReturn(emptyList())
+
+        val result = dashboardService.getDashboard(userId)
+
+        assertThat(result.currentStreak).isEqualTo(0)
+        assertThat(result.longestStreak).isEqualTo(0)
+        assertThat(result.totalLogs).isEqualTo(0)
+    }
+
+    @Test
+    fun `오늘 포함 연속 3일 로그 작성 시 스트릭은 3이다`() {
+        val logs = listOf(makeLog(0), makeLog(1), makeLog(2))
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(any(), any()))
+            .thenReturn(PageImpl(logs))
+        whenever(workLogRepository.findByUserAndDateRange(any(), any(), any()))
+            .thenReturn(logs)
+
+        val result = dashboardService.getDashboard(userId)
+
+        assertThat(result.currentStreak).isEqualTo(3)
+        assertThat(result.longestStreak).isEqualTo(3)
+    }
+
+    @Test
+    fun `어제부터 끊긴 경우 현재 스트릭은 0이다`() {
+        val logs = listOf(makeLog(1), makeLog(2), makeLog(3))
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(any(), any()))
+            .thenReturn(PageImpl(logs))
+        whenever(workLogRepository.findByUserAndDateRange(any(), any(), any()))
+            .thenReturn(emptyList())
+
+        val result = dashboardService.getDashboard(userId)
+
+        assertThat(result.currentStreak).isEqualTo(0)
+        assertThat(result.longestStreak).isEqualTo(3)
+    }
+
+    @Test
+    fun `이번주 로그 수가 정확히 집계된다`() {
+        val allLogs = listOf(makeLog(0), makeLog(1))
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(any(), any()))
+            .thenReturn(PageImpl(allLogs))
+        whenever(workLogRepository.findByUserAndDateRange(any(), any(), any()))
+            .thenReturn(allLogs)
+
+        val result = dashboardService.getDashboard(userId)
+
+        assertThat(result.thisWeekLogs).isEqualTo(2)
+    }
+
+    @Test
+    fun `최근 로그는 최대 5개까지 반환한다`() {
+        val logs = (0L..9L).map { makeLog(it) }
+        whenever(workLogRepository.findAllByUserOrderByLogDateDesc(any(), any()))
+            .thenReturn(PageImpl(logs))
+        whenever(workLogRepository.findByUserAndDateRange(any(), any(), any()))
+            .thenReturn(logs.take(2))
+
+        val result = dashboardService.getDashboard(userId)
+
+        assertThat(result.recentLogs).hasSize(5)
+    }
+}

--- a/apps/api/src/test/resources/application-test.yml
+++ b/apps/api/src/test/resources/application-test.yml
@@ -5,6 +5,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
       - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+      - org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## 관련 이슈
Closes #25

## 작업 내용

### Application
- `DashboardService`
  - 총 로그 수
  - **현재 스트릭** — 오늘부터 연속 로그 작성일 수
  - **최장 스트릭** — 역대 최장 연속 로그 작성일 수
  - 이번 주 / 이번 달 로그 수
  - 최근 로그 5개 요약
  - 최근 회고 3개 요약
  - `@Cacheable` — Redis TTL 5분

### Infrastructure
- `CacheConfig` — `@EnableCaching` + Redis 캐시 매니저
- `application.yml` dev/prod에 `spring.data.redis` 설정 추가
- `application-test.yml` Redis/Cache AutoConfiguration 제외

### Interfaces
- `DashboardController` — `GET /api/v1/dashboard`
- `DashboardResponse`, `WorkLogSummary`, `RetrospectiveSummary` DTO

### 테스트
- `DashboardServiceTest` — 5개 케이스 (스트릭 0 / 연속 3일 / 중단 / 이번주 집계 / 최근 5개)

## API 스펙

| Method | Path | 설명 |
|--------|------|------|
| GET | `/api/v1/dashboard` | 대시보드 종합 조회 (Redis 5분 캐시) |

Made with [Cursor](https://cursor.com)