### PR TITLE
[Task] Phase 3 — Kafka Consumer (work-log.saved 이벤트 수신)

### DIFF
--- a/apps/ai/app/kafka/consumer.py
+++ b/apps/ai/app/kafka/consumer.py
@@ -1,0 +1,91 @@
+import asyncio
+import json
+import logging
+
+from aiokafka import AIOKafkaConsumer
+from aiokafka.errors import KafkaConnectionError
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from app.core.config import settings
+from app.kafka.schemas import WorkLogSavedEvent
+
+logger = logging.getLogger(__name__)
+
+TOPIC_WORK_LOG_SAVED = "work-log.saved"
+
+_consumer: AIOKafkaConsumer | None = None
+_consumer_task: asyncio.Task | None = None
+
+
+async def _handle_work_log_saved(event: WorkLogSavedEvent) -> None:
+    """work-log.saved 이벤트 처리 — AI 분석 트리거"""
+    logger.info(
+        "WorkLog 수신 workLogId=%s userId=%s logDate=%s",
+        event.workLogId,
+        event.userId,
+        event.logDate,
+    )
+    # TODO: AI 분석 서비스 호출 (Phase 3 이후 태스크에서 구현)
+    # await analysis_service.trigger(event)
+
+
+async def _consume_loop(consumer: AIOKafkaConsumer) -> None:
+    try:
+        async for msg in consumer:
+            try:
+                payload = json.loads(msg.value.decode("utf-8"))
+                event = WorkLogSavedEvent(**payload)
+                await _handle_work_log_saved(event)
+            except Exception as e:
+                logger.error("이벤트 처리 실패 offset=%s: %s", msg.offset, e)
+    except asyncio.CancelledError:
+        logger.info("Kafka Consumer 루프 종료")
+    except Exception as e:
+        logger.error("Kafka Consumer 예외: %s", e)
+    finally:
+        await consumer.stop()
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    reraise=True,
+)
+async def _create_consumer() -> AIOKafkaConsumer:
+    consumer = AIOKafkaConsumer(
+        TOPIC_WORK_LOG_SAVED,
+        bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+        group_id=settings.KAFKA_GROUP_ID,
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        value_deserializer=None,  # raw bytes — _consume_loop에서 직접 파싱
+    )
+    await consumer.start()
+    logger.info("Kafka Consumer 시작 topic=%s", TOPIC_WORK_LOG_SAVED)
+    return consumer
+
+
+async def start_consumer() -> None:
+    global _consumer, _consumer_task
+    try:
+        _consumer = await _create_consumer()
+        _consumer_task = asyncio.create_task(_consume_loop(_consumer))
+    except KafkaConnectionError as e:
+        logger.error("Kafka 연결 실패 — Consumer 시작 안 됨: %s", e)
+    except Exception as e:
+        logger.error("Kafka Consumer 초기화 실패: %s", e)
+
+
+async def stop_consumer() -> None:
+    global _consumer, _consumer_task
+    if _consumer_task:
+        _consumer_task.cancel()
+        try:
+            await _consumer_task
+        except asyncio.CancelledError:
+            pass
+        _consumer_task = None
+    if _consumer:
+        await _consumer.stop()
+        _consumer = None
+    logger.info("Kafka Consumer 종료")

--- a/apps/ai/app/kafka/schemas.py
+++ b/apps/ai/app/kafka/schemas.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class WorkLogSavedEvent(BaseModel):
+    workLogId: str
+    userId: str
+    logDate: str  # ISO date: "2026-04-03"

--- a/apps/ai/app/main.py
+++ b/apps/ai/app/main.py
@@ -5,13 +5,16 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
 from app.core.database import connect_all, disconnect_all
+from app.kafka.consumer import start_consumer, stop_consumer
 from app.routers import health
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await connect_all()
+    await start_consumer()
     yield
+    await stop_consumer()
     await disconnect_all()
 
 

--- a/apps/ai/tests/test_kafka_consumer.py
+++ b/apps/ai/tests/test_kafka_consumer.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.kafka.consumer import _handle_work_log_saved
+from app.kafka.schemas import WorkLogSavedEvent
+
+
+async def test_handle_work_log_saved_logs(caplog):
+    event = WorkLogSavedEvent(
+        workLogId="aaaaaaaa-0000-0000-0000-000000000001",
+        userId="bbbbbbbb-0000-0000-0000-000000000001",
+        logDate="2026-04-03",
+    )
+    with caplog.at_level("INFO"):
+        await _handle_work_log_saved(event)
+
+    assert "aaaaaaaa-0000-0000-0000-000000000001" in caplog.text
+
+
+async def test_work_log_saved_event_schema():
+    raw = {
+        "workLogId": "aaaaaaaa-0000-0000-0000-000000000001",
+        "userId": "bbbbbbbb-0000-0000-0000-000000000001",
+        "logDate": "2026-04-03",
+    }
+    event = WorkLogSavedEvent(**raw)
+    assert event.workLogId == raw["workLogId"]
+    assert event.userId == raw["userId"]
+    assert event.logDate == raw["logDate"]


### PR DESCRIPTION
## Summary
- aiokafka 기반 비동기 Consumer 구현
- Spring Boot가 발행하는 `work-log.saved` 토픽 수신
- `WorkLogSavedEvent` 스키마 (workLogId / userId / logDate)
- Kafka 연결 실패 시 tenacity 재시도 (최대 5회, exponential backoff)
- FastAPI lifespan에 Consumer 시작/종료 연결

## 흐름
```
Spring Boot → Kafka(work-log.saved) → aiokafka Consumer → _handle_work_log_saved() → [AI 분석 트리거]
```

## Test plan
- [ ] `WorkLogSavedEvent` 파싱 정상 동작 확인
- [ ] 핸들러 로그 출력 확인

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)