### PR TITLE
[Task] Phase 3 — RAG 파이프라인 (pgvector + 임베딩)

### DIFF
--- a/apps/ai/app/kafka/consumer.py
+++ b/apps/ai/app/kafka/consumer.py
@@ -1,13 +1,16 @@
 import asyncio
 import json
 import logging
+import uuid
 
 from aiokafka import AIOKafkaConsumer
 from aiokafka.errors import KafkaConnectionError
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from app.core.config import settings
+from app.core.database import AsyncSessionLocal
 from app.kafka.schemas import WorkLogSavedEvent
+from app.services.embedding_service import embed_work_log
 
 logger = logging.getLogger(__name__)
 
@@ -18,15 +21,15 @@ _consumer_task: asyncio.Task | None = None
 
 
 async def _handle_work_log_saved(event: WorkLogSavedEvent) -> None:
-    """work-log.saved 이벤트 처리 — AI 분석 트리거"""
+    """work-log.saved 이벤트 처리 — 임베딩 생성"""
     logger.info(
         "WorkLog 수신 workLogId=%s userId=%s logDate=%s",
         event.workLogId,
         event.userId,
         event.logDate,
     )
-    # TODO: AI 분석 서비스 호출 (Phase 3 이후 태스크에서 구현)
-    # await analysis_service.trigger(event)
+    async with AsyncSessionLocal() as db:
+        await embed_work_log(uuid.UUID(event.workLogId), db)
 
 
 async def _consume_loop(consumer: AIOKafkaConsumer) -> None:

--- a/apps/ai/app/models/work_log.py
+++ b/apps/ai/app/models/work_log.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import date, datetime
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import Date, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class WorkLog(Base):
+    """Spring Boot가 관리하는 work_logs 테이블 (읽기 전용)"""
+
+    __tablename__ = "work_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    log_date: Mapped[date] = mapped_column(Date, nullable=False)
+    mood: Mapped[str | None] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class WorkLogEmbedding(Base):
+    """AI 서버가 관리하는 work_log_embeddings 테이블"""
+
+    __tablename__ = "work_log_embeddings"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    work_log_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("work_logs.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
+    embedding: Mapped[list[float]] = mapped_column(Vector(1536), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/apps/ai/app/services/embedding_service.py
+++ b/apps/ai/app/services/embedding_service.py
@@ -1,0 +1,61 @@
+import logging
+import uuid
+
+from openai import AsyncOpenAI
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.work_log import WorkLog, WorkLogEmbedding
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIM = 1536
+
+_openai_client: AsyncOpenAI | None = None
+
+
+def _get_openai() -> AsyncOpenAI:
+    global _openai_client
+    if _openai_client is None:
+        _openai_client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+    return _openai_client
+
+
+def _build_embed_text(work_log: WorkLog) -> str:
+    """임베딩할 텍스트 구성 — 제목 + 내용 + 날짜"""
+    return f"[{work_log.log_date}] {work_log.title}\n{work_log.content}"
+
+
+async def generate_embedding(text: str) -> list[float]:
+    response = await _get_openai().embeddings.create(
+        input=text,
+        model=EMBEDDING_MODEL,
+    )
+    return response.data[0].embedding
+
+
+async def embed_work_log(work_log_id: uuid.UUID, db: AsyncSession) -> None:
+    """WorkLog를 조회해 임베딩 생성 후 저장"""
+    work_log = await db.get(WorkLog, work_log_id)
+    if work_log is None:
+        logger.warning("WorkLog 없음 workLogId=%s", work_log_id)
+        return
+
+    text = _build_embed_text(work_log)
+    vector = await generate_embedding(text)
+
+    # upsert: 이미 있으면 업데이트
+    result = await db.execute(
+        select(WorkLogEmbedding).where(WorkLogEmbedding.work_log_id == work_log_id)
+    )
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.embedding = vector
+    else:
+        db.add(WorkLogEmbedding(work_log_id=work_log_id, embedding=vector))
+
+    await db.commit()
+    logger.info("임베딩 저장 완료 workLogId=%s", work_log_id)

--- a/apps/ai/app/services/rag_service.py
+++ b/apps/ai/app/services/rag_service.py
@@ -1,0 +1,79 @@
+import uuid
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.work_log import WorkLog, WorkLogEmbedding
+from app.services.embedding_service import generate_embedding
+
+
+@dataclass
+class SimilarWorkLog:
+    work_log_id: uuid.UUID
+    title: str
+    content: str
+    log_date: date
+    similarity: float
+
+
+async def search_similar(
+    query: str,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    top_k: int = 5,
+) -> list[SimilarWorkLog]:
+    """쿼리와 유사한 WorkLog를 코사인 유사도로 검색"""
+    query_vector = await generate_embedding(query)
+
+    # pgvector 코사인 유사도 (<=> 연산자: 거리, 1 - distance = similarity)
+    stmt = (
+        select(
+            WorkLog.id,
+            WorkLog.title,
+            WorkLog.content,
+            WorkLog.log_date,
+            (1 - WorkLogEmbedding.embedding.cosine_distance(query_vector)).label(
+                "similarity"
+            ),
+        )
+        .join(WorkLogEmbedding, WorkLog.id == WorkLogEmbedding.work_log_id)
+        .where(WorkLog.user_id == user_id)
+        .order_by(text("similarity DESC"))
+        .limit(top_k)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    return [
+        SimilarWorkLog(
+            work_log_id=row.id,
+            title=row.title,
+            content=row.content,
+            log_date=row.log_date,
+            similarity=float(row.similarity),
+        )
+        for row in rows
+    ]
+
+
+async def build_rag_context(
+    query: str,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    top_k: int = 5,
+) -> str:
+    """유사 WorkLog를 LLM 프롬프트에 삽입할 컨텍스트 문자열로 반환"""
+    similar = await search_similar(query, user_id, db, top_k)
+    if not similar:
+        return ""
+
+    lines = ["## 관련 작업 로그\n"]
+    for i, log in enumerate(similar, 1):
+        lines.append(f"### {i}. [{log.log_date}] {log.title}")
+        lines.append(log.content)
+        lines.append("")
+
+    return "\n".join(lines)

--- a/apps/ai/pyproject.toml
+++ b/apps/ai/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.14.0",
     "pytest-cov>=5.0.0",
     "httpx>=0.27.0",
     "ruff>=0.5.0",

--- a/apps/ai/tests/test_rag_service.py
+++ b/apps/ai/tests/test_rag_service.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.rag_service import SimilarWorkLog, build_rag_context
+
+
+async def test_build_rag_context_empty(mocker):
+    mock_db = AsyncMock()
+    mocker.patch(
+        "app.services.rag_service.search_similar",
+        return_value=[],
+    )
+    result = await build_rag_context("회고", uuid.uuid4(), mock_db)
+    assert result == ""
+
+
+async def test_build_rag_context_with_results(mocker):
+    mock_db = AsyncMock()
+    mock_logs = [
+        SimilarWorkLog(
+            work_log_id=uuid.uuid4(),
+            title="FastAPI 공부",
+            content="오늘 FastAPI 라우터를 구현했다.",
+            log_date=date(2026, 4, 1),
+            similarity=0.92,
+        )
+    ]
+    mocker.patch(
+        "app.services.rag_service.search_similar",
+        return_value=mock_logs,
+    )
+    result = await build_rag_context("FastAPI", uuid.uuid4(), mock_db)
+    assert "FastAPI 공부" in result
+    assert "2026-04-01" in result


### PR DESCRIPTION
## Summary
- `WorkLog` / `WorkLogEmbedding` SQLAlchemy 모델 (기존 Spring Boot DB 스키마 사용)
- OpenAI `text-embedding-3-small`으로 임베딩 생성 (1536차원)
- WorkLog 저장 이벤트 수신 시 자동 임베딩 → `work_log_embeddings` upsert
- pgvector 코사인 유사도 검색 (`search_similar`)
- LLM 프롬프트용 컨텍스트 빌더 (`build_rag_context`)

## 흐름
```
Kafka 수신 → embed_work_log() → OpenAI API → work_log_embeddings 저장
LangGraph Agent → build_rag_context() → pgvector 검색 → 프롬프트 컨텍스트
```

## Test plan
- [ ] `build_rag_context` — 결과 없을 때 빈 문자열 반환
- [ ] `build_rag_context` — 결과 있을 때 제목/날짜 포함 확인

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)