### PR TITLE
feat(ai): LangGraph 성장 코칭 Agent 구현 (#36)

### DIFF
--- a/apps/ai/app/agents/coaching/graph.py
+++ b/apps/ai/app/agents/coaching/graph.py
@@ -1,0 +1,47 @@
+from langgraph.graph import END, START, StateGraph
+
+from app.agents.coaching.nodes import (
+    analyze_weak_stacks,
+    collect_recent_logs,
+    generate_roadmap,
+    save_to_mongo,
+    search_resources,
+)
+from app.agents.coaching.state import CoachingState
+
+
+def build_coaching_graph() -> StateGraph:
+    graph = StateGraph(CoachingState)
+
+    graph.add_node("collect_recent_logs", collect_recent_logs)
+    graph.add_node("analyze_weak_stacks", analyze_weak_stacks)
+    graph.add_node("search_resources", search_resources)
+    graph.add_node("generate_roadmap", generate_roadmap)
+    graph.add_node("save_to_mongo", save_to_mongo)
+
+    graph.add_edge(START, "collect_recent_logs")
+    graph.add_edge("collect_recent_logs", "analyze_weak_stacks")
+    graph.add_edge("analyze_weak_stacks", "search_resources")
+    graph.add_edge("search_resources", "generate_roadmap")
+    graph.add_edge("generate_roadmap", "save_to_mongo")
+    graph.add_edge("save_to_mongo", END)
+
+    return graph.compile()
+
+
+# 싱글턴 컴파일 그래프
+coaching_graph = build_coaching_graph()
+
+
+async def run_coaching_agent(user_id: str) -> CoachingState:
+    initial_state = CoachingState(
+        user_id=user_id,
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+    return await coaching_graph.ainvoke(initial_state)

--- a/apps/ai/app/agents/coaching/nodes.py
+++ b/apps/ai/app/agents/coaching/nodes.py
@@ -1,0 +1,210 @@
+import json
+import logging
+import uuid
+from datetime import date, datetime, timedelta
+
+from langchain_anthropic import ChatAnthropic
+from langchain_community.tools import DuckDuckGoSearchRun
+from langchain_core.messages import HumanMessage, SystemMessage
+from sqlalchemy import select
+
+from app.agents.coaching.state import CoachingState
+from app.agents.retrospective.state import WorkLogItem
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal, get_mongo_db
+from app.models.work_log import WorkLog
+from app.services.rag_service import build_rag_context
+
+logger = logging.getLogger(__name__)
+
+_llm: ChatAnthropic | None = None
+_search: DuckDuckGoSearchRun | None = None
+
+
+def _get_llm() -> ChatAnthropic:
+    global _llm
+    if _llm is None:
+        _llm = ChatAnthropic(
+            model="claude-sonnet-4-6",
+            api_key=settings.ANTHROPIC_API_KEY,
+            max_tokens=4096,
+        )
+    return _llm
+
+
+def _get_search() -> DuckDuckGoSearchRun:
+    global _search
+    if _search is None:
+        _search = DuckDuckGoSearchRun()
+    return _search
+
+
+# ── Node 1: 최근 3개월 WorkLog 수집 ──────────────────────────────────────────
+
+async def collect_recent_logs(state: CoachingState) -> CoachingState:
+    user_id = uuid.UUID(state["user_id"])
+    period_to = date.today()
+    period_from = period_to - timedelta(days=90)
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(WorkLog)
+            .where(
+                WorkLog.user_id == user_id,
+                WorkLog.log_date >= period_from,
+                WorkLog.log_date <= period_to,
+            )
+            .order_by(WorkLog.log_date.desc())
+        )
+        logs = result.scalars().all()
+
+    recent_logs: list[WorkLogItem] = [
+        WorkLogItem(
+            id=str(log.id),
+            title=log.title,
+            content=log.content,
+            log_date=str(log.log_date),
+            mood=log.mood,
+        )
+        for log in logs
+    ]
+
+    logger.info(
+        "최근 3개월 WorkLog 수집 완료 userId=%s count=%d",
+        state["user_id"],
+        len(recent_logs),
+    )
+    return {**state, "recent_logs": recent_logs}
+
+
+# ── Node 2: 부족한 기술 스택 파악 (RAG + LLM) ────────────────────────────────
+
+async def analyze_weak_stacks(state: CoachingState) -> CoachingState:
+    if not state["recent_logs"]:
+        return {**state, "rag_context": "", "weak_stacks": []}
+
+    query = " ".join(log["title"] for log in state["recent_logs"][:20])
+    user_id = uuid.UUID(state["user_id"])
+
+    async with AsyncSessionLocal() as db:
+        rag_context = await build_rag_context(query, user_id, db, top_k=10)
+
+    logs_text = "\n".join(
+        f"[{log['log_date']}] {log['title']}: {log['content'][:200]}"
+        for log in state["recent_logs"][:30]
+    )
+
+    system_prompt = """당신은 개발자 성장을 분석하는 AI 코치입니다.
+작업 로그를 분석하여 개발자가 자주 다루는 기술과 부족하거나 더 발전이 필요한 기술 스택을 파악해주세요."""
+
+    human_prompt = f"""## 최근 3개월 작업 로그
+{logs_text}
+
+{f"## 과거 패턴 (RAG){chr(10)}{rag_context}" if rag_context else ""}
+
+위 로그를 분석하여 이 개발자가 학습을 강화해야 할 기술 스택 3~5가지를 파악해주세요.
+응답은 JSON 배열 형식으로만 반환하세요: ["기술1", "기술2", "기술3"]
+각 항목은 구체적인 기술명으로 작성하세요 (예: "Kubernetes", "Redis 캐싱 전략", "JUnit 테스트")."""
+
+    response = await _get_llm().ainvoke(
+        [SystemMessage(content=system_prompt), HumanMessage(content=human_prompt)]
+    )
+    raw = response.content.strip()
+
+    try:
+        if "```" in raw:
+            raw = raw.split("```")[1].replace("json", "").strip()
+        weak_stacks = json.loads(raw)
+        if not isinstance(weak_stacks, list):
+            weak_stacks = [str(weak_stacks)]
+    except Exception:
+        weak_stacks = [raw]
+
+    logger.info("부족 스택 파악 완료 userId=%s stacks=%s", state["user_id"], weak_stacks)
+    return {**state, "rag_context": rag_context, "weak_stacks": weak_stacks}
+
+
+# ── Node 3: 학습 리소스 웹 검색 ──────────────────────────────────────────────
+
+async def search_resources(state: CoachingState) -> CoachingState:
+    if not state["weak_stacks"]:
+        return {**state, "search_results": {}}
+
+    search = _get_search()
+    search_results: dict[str, str] = {}
+
+    for stack in state["weak_stacks"]:
+        try:
+            query = f"{stack} 학습 로드맵 튜토리얼 추천 2024 2025"
+            result = search.run(query)
+            search_results[stack] = result[:800]  # 토큰 절약
+            logger.info("웹 검색 완료 stack=%s", stack)
+        except Exception as e:
+            logger.warning("웹 검색 실패 stack=%s error=%s", stack, e)
+            search_results[stack] = ""
+
+    return {**state, "search_results": search_results}
+
+
+# ── Node 4: 개인화 학습 로드맵 생성 ──────────────────────────────────────────
+
+async def generate_roadmap(state: CoachingState) -> CoachingState:
+    if not state["weak_stacks"]:
+        return {**state, "roadmap": "분석할 작업 로그가 없습니다."}
+
+    stacks_section = "\n".join(f"- {s}" for s in state["weak_stacks"])
+
+    resources_section = ""
+    for stack, result in state.get("search_results", {}).items():
+        if result:
+            resources_section += f"\n### {stack}\n{result}\n"
+
+    logs_summary = "\n".join(
+        f"[{log['log_date']}] {log['title']}"
+        for log in state["recent_logs"][:15]
+    )
+
+    system_prompt = """당신은 개발자의 성장을 돕는 AI 코치입니다.
+분석 결과를 바탕으로 구체적이고 실천 가능한 개인화 학습 로드맵을 마크다운으로 작성해주세요."""
+
+    human_prompt = f"""## 개발자 최근 활동 요약
+{logs_summary}
+
+## 학습이 필요한 기술 스택
+{stacks_section}
+
+## 웹 검색 학습 리소스
+{resources_section if resources_section else "검색 결과 없음"}
+
+위 정보를 바탕으로 개인화된 8주 학습 로드맵을 작성해주세요.
+형식:
+- 전체 목표 (2~3줄)
+- 주차별 학습 계획 (1~8주, 각 주차별 목표 + 구체적 학습 항목)
+- 추천 리소스 (책, 강의, 공식 문서 링크 등)
+- 실천 팁 (3가지)
+
+한국어로 작성하고 마크다운 형식을 사용하세요."""
+
+    response = await _get_llm().ainvoke(
+        [SystemMessage(content=system_prompt), HumanMessage(content=human_prompt)]
+    )
+
+    roadmap = response.content.strip()
+    logger.info("로드맵 생성 완료 userId=%s", state["user_id"])
+    return {**state, "roadmap": roadmap}
+
+
+# ── Node 5: MongoDB 저장 ──────────────────────────────────────────────────────
+
+async def save_to_mongo(state: CoachingState) -> CoachingState:
+    db = get_mongo_db()
+    doc = {
+        "user_id": state["user_id"],
+        "log_count": len(state.get("recent_logs", [])),
+        "weak_stacks": state.get("weak_stacks", []),
+        "roadmap": state.get("roadmap", ""),
+        "created_at": datetime.utcnow(),
+    }
+    result = await db["coaching_results"].insert_one(doc)
+    logger.info("MongoDB 저장 완료 docId=%s", result.inserted_id)
+    return {**state, "mongo_doc_id": str(result.inserted_id)}

--- a/apps/ai/app/agents/coaching/state.py
+++ b/apps/ai/app/agents/coaching/state.py
@@ -1,0 +1,21 @@
+from typing import TypedDict
+
+from app.agents.retrospective.state import WorkLogItem
+
+
+class CoachingState(TypedDict):
+    # 입력
+    user_id: str
+
+    # 중간 상태
+    recent_logs: list[WorkLogItem]   # 최근 3개월 작업 로그
+    rag_context: str                  # 벡터 검색 컨텍스트
+    weak_stacks: list[str]            # 부족한 기술 스택 목록
+    search_results: dict[str, str]    # stack -> 검색 결과
+
+    # 출력
+    roadmap: str                      # 개인화 학습 로드맵 (마크다운)
+
+    # 저장 결과
+    mongo_doc_id: str | None
+    error: str | None

--- a/apps/ai/app/routers/agent.py
+++ b/apps/ai/app/routers/agent.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from app.agents.coaching.graph import run_coaching_agent
 from app.agents.retrospective.graph import run_retrospective_agent
 
 router = APIRouter(prefix="/agents", tags=["agents"])
@@ -30,5 +31,25 @@ async def trigger_retrospective_agent(body: RetrospectiveRequest):
         draft_title=result["draft_title"],
         draft_content=result["draft_content"],
         goals=result["goals"],
+        mongo_doc_id=result.get("mongo_doc_id"),
+    )
+
+
+class CoachingRequest(BaseModel):
+    user_id: str
+
+
+class CoachingResponse(BaseModel):
+    weak_stacks: list[str]
+    roadmap: str
+    mongo_doc_id: str | None
+
+
+@router.post("/coaching", response_model=CoachingResponse)
+async def trigger_coaching_agent(body: CoachingRequest):
+    result = await run_coaching_agent(user_id=body.user_id)
+    return CoachingResponse(
+        weak_stacks=result["weak_stacks"],
+        roadmap=result["roadmap"],
         mongo_doc_id=result.get("mongo_doc_id"),
     )

--- a/apps/ai/pyproject.toml
+++ b/apps/ai/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "langchain-openai>=0.2.0",
     "langchain-anthropic>=0.3.0",
     "langchain-community>=0.3.0",
+    "duckduckgo-search>=6.0.0",
     "langgraph>=0.2.0",
     "openai>=1.40.0",
     "anthropic>=0.34.0",

--- a/apps/ai/tests/test_coaching_agent.py
+++ b/apps/ai/tests/test_coaching_agent.py
@@ -1,0 +1,249 @@
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+async def test_collect_recent_logs_empty(mocker):
+    """작업 로그가 없는 경우 빈 리스트 반환"""
+    user_id = str(uuid.uuid4())
+
+    mocker.patch(
+        "app.agents.coaching.nodes.AsyncSessionLocal",
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(
+                return_value=AsyncMock(
+                    execute=AsyncMock(
+                        return_value=AsyncMock(scalars=lambda: AsyncMock(all=lambda: []))
+                    )
+                )
+            ),
+            __aexit__=AsyncMock(return_value=False),
+        ),
+    )
+
+    from app.agents.coaching.nodes import collect_recent_logs
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=user_id,
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await collect_recent_logs(state)
+    assert result["recent_logs"] == []
+
+
+async def test_analyze_weak_stacks_no_logs(mocker):
+    """로그 없을 때 빈 weak_stacks 반환"""
+    from app.agents.coaching.nodes import analyze_weak_stacks
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=str(uuid.uuid4()),
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await analyze_weak_stacks(state)
+    assert result["weak_stacks"] == []
+    assert result["rag_context"] == ""
+
+
+async def test_analyze_weak_stacks_with_logs(mocker):
+    """로그 있을 때 LLM이 반환한 스택 목록 파싱"""
+    user_id = str(uuid.uuid4())
+
+    mocker.patch(
+        "app.agents.coaching.nodes.AsyncSessionLocal",
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=AsyncMock()),
+            __aexit__=AsyncMock(return_value=False),
+        ),
+    )
+    mocker.patch(
+        "app.agents.coaching.nodes.build_rag_context",
+        new=AsyncMock(return_value=""),
+    )
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(
+        return_value=MagicMock(content='["Kubernetes", "Redis", "JUnit"]')
+    )
+    mocker.patch("app.agents.coaching.nodes._get_llm", return_value=mock_llm)
+
+    from app.agents.coaching.nodes import analyze_weak_stacks
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=user_id,
+        recent_logs=[
+            {"id": "1", "title": "FastAPI 구현", "content": "...", "log_date": "2026-01-01", "mood": None}
+        ],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await analyze_weak_stacks(state)
+    assert result["weak_stacks"] == ["Kubernetes", "Redis", "JUnit"]
+
+
+async def test_search_resources_empty_stacks():
+    """스택 없으면 검색 스킵"""
+    from app.agents.coaching.nodes import search_resources
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=str(uuid.uuid4()),
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await search_resources(state)
+    assert result["search_results"] == {}
+
+
+async def test_search_resources_with_stacks(mocker):
+    """스택별 DuckDuckGo 검색 수행"""
+    mock_search = MagicMock()
+    mock_search.run = MagicMock(return_value="검색 결과 텍스트")
+    mocker.patch("app.agents.coaching.nodes._get_search", return_value=mock_search)
+
+    from app.agents.coaching.nodes import search_resources
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=str(uuid.uuid4()),
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=["Kubernetes", "Redis"],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await search_resources(state)
+    assert "Kubernetes" in result["search_results"]
+    assert "Redis" in result["search_results"]
+    assert result["search_results"]["Kubernetes"] == "검색 결과 텍스트"
+
+
+async def test_generate_roadmap_no_stacks():
+    """스택 없으면 기본 메시지 반환"""
+    from app.agents.coaching.nodes import generate_roadmap
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=str(uuid.uuid4()),
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=[],
+        search_results={},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await generate_roadmap(state)
+    assert result["roadmap"] == "분석할 작업 로그가 없습니다."
+
+
+async def test_generate_roadmap_with_stacks(mocker):
+    """스택 있을 때 LLM으로 로드맵 생성"""
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="# 8주 학습 로드맵\n..."))
+    mocker.patch("app.agents.coaching.nodes._get_llm", return_value=mock_llm)
+
+    from app.agents.coaching.nodes import generate_roadmap
+    from app.agents.coaching.state import CoachingState
+
+    state = CoachingState(
+        user_id=str(uuid.uuid4()),
+        recent_logs=[],
+        rag_context="",
+        weak_stacks=["Kubernetes"],
+        search_results={"Kubernetes": "검색 결과"},
+        roadmap="",
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await generate_roadmap(state)
+    assert "8주" in result["roadmap"]
+
+
+async def test_run_coaching_agent_full(mocker):
+    """전체 그래프 실행 통합 테스트"""
+    user_id = str(uuid.uuid4())
+
+    mocker.patch(
+        "app.agents.coaching.nodes.AsyncSessionLocal",
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(
+                return_value=AsyncMock(
+                    execute=AsyncMock(
+                        return_value=AsyncMock(scalars=lambda: AsyncMock(all=lambda: []))
+                    )
+                )
+            ),
+            __aexit__=AsyncMock(return_value=False),
+        ),
+    )
+    mocker.patch(
+        "app.agents.coaching.nodes.build_rag_context",
+        new=AsyncMock(return_value=""),
+    )
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(
+        side_effect=[
+            MagicMock(content='["Kubernetes", "Redis"]'),       # analyze_weak_stacks
+            MagicMock(content="# 8주 학습 로드맵\n내용"),        # generate_roadmap
+        ]
+    )
+    mocker.patch("app.agents.coaching.nodes._get_llm", return_value=mock_llm)
+
+    mock_search = MagicMock()
+    mock_search.run = MagicMock(return_value="검색 결과")
+    mocker.patch("app.agents.coaching.nodes._get_search", return_value=mock_search)
+
+    mocker.patch(
+        "app.agents.coaching.nodes.get_mongo_db",
+        return_value=MagicMock(
+            **{
+                "__getitem__": lambda s, k: AsyncMock(
+                    insert_one=AsyncMock(
+                        return_value=MagicMock(inserted_id="mongo123")
+                    )
+                )
+            }
+        ),
+    )
+
+    from app.agents.coaching.graph import run_coaching_agent
+
+    result = await run_coaching_agent(user_id=user_id)
+
+    assert result["user_id"] == user_id
+    assert isinstance(result["weak_stacks"], list)
+    assert isinstance(result["roadmap"], str)
+    assert result["mongo_doc_id"] == "mongo123"


### PR DESCRIPTION
## Summary
- LangGraph StateGraph 5단계 흐름: 로그 수집 → 부족 스택 파악 → 웹 검색 → 로드맵 생성 → MongoDB 저장
- RAG(pgvector)로 최근 3개월 작업 로그 벡터 검색 후 LLM 컨텍스트 주입
- DuckDuckGoSearchRun으로 기술 스택별 학습 리소스 자동 검색
- `POST /agents/coaching` 엔드포인트 추가

## Closes
Closes #36

## 변경 파일
- `app/agents/coaching/state.py` — CoachingState TypedDict
- `app/agents/coaching/nodes.py` — 5개 노드 구현
- `app/agents/coaching/graph.py` — StateGraph 빌더 + 싱글턴
- `app/routers/agent.py` — /coaching 엔드포인트 추가
- `pyproject.toml` — duckduckgo-search 의존성 추가
- `tests/test_coaching_agent.py` — pytest 8개 케이스

## Test plan
- [ ] `pytest tests/test_coaching_agent.py` — 8개 케이스 통과 확인
- [ ] 로그 없는 유저 → `weak_stacks: []`, `roadmap: "분석할 작업 로그가 없습니다."` 반환 확인
- [ ] 로그 있는 유저 → DuckDuckGo 검색 + 로드맵 생성 + MongoDB 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)