### PR TITLE
feat(ai): Fine-tuning 학습 데이터셋 준비 스크립트 구현 (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ coverage/
 .turbo
 
 docs/devlog
+
+# Fine-tuning 데이터셋 (생성된 데이터, 모델 가중치)
+apps/ai/fine_tuning/data/
+apps/ai/fine_tuning/*.jsonl

--- a/apps/ai/fine_tuning/build_dataset.py
+++ b/apps/ai/fine_tuning/build_dataset.py
@@ -1,0 +1,117 @@
+"""실제 데이터 + 합성 데이터를 병합하여 최종 학습 데이터셋(train/val) 생성.
+
+사용법:
+    python -m fine_tuning.build_dataset \
+        --real fine_tuning/data/real.jsonl \
+        --synthetic fine_tuning/data/synthetic.jsonl \
+        --output-dir fine_tuning/data \
+        --val-ratio 0.1
+"""
+
+import argparse
+import json
+import logging
+import random
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        logger.warning("파일 없음: %s", path)
+        return []
+    with path.open(encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def validate_sample(sample: dict) -> bool:
+    """최소 품질 기준 검증"""
+    messages = sample.get("messages", [])
+    if len(messages) != 3:
+        return False
+    roles = [m.get("role") for m in messages]
+    if roles != ["system", "user", "assistant"]:
+        return False
+    # assistant 응답이 너무 짧으면 제외
+    assistant_content = messages[2].get("content", "")
+    if len(assistant_content) < 200:
+        return False
+    return True
+
+
+def build_final_dataset(
+    real_path: Path,
+    synthetic_path: Path,
+    output_dir: Path,
+    val_ratio: float = 0.1,
+    seed: int = 42,
+) -> tuple[int, int]:
+    """병합 → 정제 → train/val 분리 → 저장.
+
+    Returns:
+        (train_count, val_count)
+    """
+    real_samples = load_jsonl(real_path)
+    synthetic_samples = load_jsonl(synthetic_path)
+
+    logger.info("실제: %d건, 합성: %d건", len(real_samples), len(synthetic_samples))
+
+    all_samples = real_samples + synthetic_samples
+
+    # 품질 검증
+    valid_samples = [s for s in all_samples if validate_sample(s)]
+    dropped = len(all_samples) - len(valid_samples)
+    if dropped:
+        logger.warning("품질 기준 미달로 %d건 제외", dropped)
+
+    # 중복 제거 (assistant content 기준)
+    seen: set[str] = set()
+    deduped = []
+    for s in valid_samples:
+        key = s["messages"][2]["content"][:100]
+        if key not in seen:
+            seen.add(key)
+            deduped.append(s)
+    logger.info("중복 제거 후: %d건 → %d건", len(valid_samples), len(deduped))
+
+    # 셔플 후 train/val 분리
+    random.seed(seed)
+    random.shuffle(deduped)
+
+    val_count = max(1, int(len(deduped) * val_ratio))
+    val_samples = deduped[:val_count]
+    train_samples = deduped[val_count:]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    train_path = output_dir / "train.jsonl"
+    val_path = output_dir / "val.jsonl"
+
+    with train_path.open("w", encoding="utf-8") as f:
+        for s in train_samples:
+            f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+    with val_path.open("w", encoding="utf-8") as f:
+        for s in val_samples:
+            f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+    logger.info("train: %d건 → %s", len(train_samples), train_path)
+    logger.info("val:   %d건 → %s", len(val_samples), val_path)
+    return len(train_samples), len(val_samples)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="최종 학습 데이터셋(train/val) 생성")
+    parser.add_argument("--real", type=Path, default=Path("fine_tuning/data/real.jsonl"))
+    parser.add_argument("--synthetic", type=Path, default=Path("fine_tuning/data/synthetic.jsonl"))
+    parser.add_argument("--output-dir", type=Path, default=Path("fine_tuning/data"))
+    parser.add_argument("--val-ratio", type=float, default=0.1, help="검증 셋 비율 (기본: 0.1)")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    build_final_dataset(args.real, args.synthetic, args.output_dir, args.val_ratio, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ai/fine_tuning/generate_synthetic.py
+++ b/apps/ai/fine_tuning/generate_synthetic.py
@@ -1,0 +1,156 @@
+"""Claude API로 합성 학습 데이터 생성.
+
+실제 데이터가 부족할 때 Claude를 활용해 다양한 WorkLog + 회고 페어를 생성합니다.
+
+사용법:
+    python -m fine_tuning.generate_synthetic --count 100 --output fine_tuning/data/synthetic.jsonl
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import random
+from pathlib import Path
+
+import anthropic
+
+from app.core.config import settings
+from fine_tuning.schema import build_sample
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# 다양한 개발자 페르소나와 기술 스택 조합
+_PERSONAS = [
+    {"role": "백엔드 개발자", "stacks": ["Spring Boot", "Kotlin", "PostgreSQL", "Redis", "Kafka"]},
+    {"role": "프론트엔드 개발자", "stacks": ["React", "TypeScript", "Next.js", "TailwindCSS", "Zustand"]},
+    {"role": "풀스택 개발자", "stacks": ["FastAPI", "Python", "Vue.js", "Docker", "GitHub Actions"]},
+    {"role": "AI/ML 엔지니어", "stacks": ["PyTorch", "LangChain", "HuggingFace", "RAG", "LangGraph"]},
+    {"role": "DevOps 엔지니어", "stacks": ["Kubernetes", "Terraform", "AWS", "Prometheus", "Grafana"]},
+]
+
+_MOODS_WEIGHTS = {
+    "GREAT": 0.2,
+    "GOOD": 0.4,
+    "NEUTRAL": 0.2,
+    "BAD": 0.15,
+    "TERRIBLE": 0.05,
+}
+
+_PERIOD_WEEKS = ["2026-01-06~2026-01-10", "2026-01-13~2026-01-17", "2026-01-20~2026-01-24",
+                 "2026-02-03~2026-02-07", "2026-02-10~2026-02-14", "2026-03-03~2026-03-07"]
+
+
+async def generate_one_sample(client: anthropic.AsyncAnthropic, persona: dict, period: str) -> dict | None:
+    """Claude로 WorkLog 묶음 + 회고 한 쌍 생성"""
+    period_from, period_to = period.split("~")
+    stacks = random.sample(persona["stacks"], k=min(3, len(persona["stacks"])))
+    mood = random.choices(list(_MOODS_WEIGHTS.keys()), weights=list(_MOODS_WEIGHTS.values()))[0]
+
+    prompt = f"""당신은 {persona['role']}입니다. 아래 조건에 맞는 가상의 주간 작업 로그 4~6개와 해당 주간의 회고를 생성해주세요.
+
+조건:
+- 기간: {period_from} ~ {period_to}
+- 기술 스택: {', '.join(stacks)}
+- 전반적인 기분/컨디션: {mood}
+- 로그는 실제 개발 업무처럼 구체적이고 자연스럽게
+
+응답 형식 (JSON):
+{{
+  "logs": [
+    {{"date": "YYYY-MM-DD", "title": "작업 제목", "content": "작업 내용 2~4문장"}},
+    ...
+  ],
+  "retrospective": "마크다운 회고 전문 (제목 포함, 400자 이상)"
+}}
+
+JSON만 반환하세요."""
+
+    try:
+        response = await client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = response.content[0].text.strip()
+
+        # JSON 코드블록 제거
+        if "```" in raw:
+            raw = raw.split("```")[1].replace("json", "").strip()
+
+        data = json.loads(raw)
+        logs = data.get("logs", [])
+        retrospective = data.get("retrospective", "")
+
+        if not logs or not retrospective or len(retrospective) < 200:
+            return None
+
+        logs_text = "\n\n".join(
+            f"[{log['date']}] {log['title']}\n{log['content']}" for log in logs
+        )
+        sample = build_sample(
+            logs_text=logs_text,
+            period_from=period_from,
+            period_to=period_to,
+            retrospective=retrospective,
+            source="synthetic",
+        )
+        return sample.to_dict()
+
+    except Exception as e:
+        logger.warning("샘플 생성 실패: %s", e)
+        return None
+
+
+async def generate_synthetic_dataset(output_path: Path, count: int, concurrency: int = 5) -> int:
+    """합성 데이터 count개 생성 후 JSONL 저장.
+
+    Returns:
+        실제 저장된 샘플 수
+    """
+    client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+
+    # 페르소나 × 기간 조합 생성
+    combos = [
+        (random.choice(_PERSONAS), random.choice(_PERIOD_WEEKS))
+        for _ in range(count)
+    ]
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def bounded(persona, period):
+        async with semaphore:
+            return await generate_one_sample(client, persona, period)
+
+    tasks = [bounded(p, w) for p, w in combos]
+    results = await asyncio.gather(*tasks)
+
+    samples = [r for r in results if r is not None]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        for sample in samples:
+            f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    logger.info("합성 데이터 %d/%d건 저장 → %s", len(samples), count, output_path)
+    return len(samples)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Claude API로 합성 학습 데이터 생성")
+    parser.add_argument("--count", type=int, default=100, help="생성할 샘플 수 (기본: 100)")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("fine_tuning/data/synthetic.jsonl"),
+        help="출력 JSONL 파일 경로",
+    )
+    parser.add_argument("--concurrency", type=int, default=5, help="동시 요청 수 (기본: 5)")
+    args = parser.parse_args()
+
+    asyncio.run(generate_synthetic_dataset(args.output, args.count, args.concurrency))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ai/fine_tuning/prepare_dataset.py
+++ b/apps/ai/fine_tuning/prepare_dataset.py
@@ -1,0 +1,120 @@
+"""실제 DB 데이터로 Fine-tuning 데이터셋 생성.
+
+WorkLog + Retrospective 페어를 PostgreSQL에서 읽어 ChatML JSONL로 변환합니다.
+
+사용법:
+    python -m fine_tuning.prepare_dataset --output fine_tuning/data/real.jsonl
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy import Date, String, Text, select
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import AsyncSessionLocal, Base
+from app.models.work_log import WorkLog
+from fine_tuning.schema import build_sample
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# Retrospective 읽기 전용 모델 (Spring Boot가 관리하는 테이블)
+class Retrospective(Base):
+    __tablename__ = "retrospectives"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    period_from: Mapped[str] = mapped_column(Date, nullable=False)
+    period_to: Mapped[str] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="PUBLISHED")
+
+
+async def export_real_samples(output_path: Path, min_log_count: int = 3) -> int:
+    """실제 DB에서 (WorkLog 묶음, Retrospective) 페어를 추출해 JSONL로 저장.
+
+    Returns:
+        저장된 샘플 수
+    """
+    samples = []
+
+    async with AsyncSessionLocal() as db:
+        # PUBLISHED 상태 회고만 추출
+        retros_result = await db.execute(
+            select(Retrospective).where(Retrospective.status == "PUBLISHED")
+        )
+        retrospectives = retros_result.scalars().all()
+        logger.info("PUBLISHED 회고 %d건 조회", len(retrospectives))
+
+        for retro in retrospectives:
+            # 해당 기간의 WorkLog 수집
+            logs_result = await db.execute(
+                select(WorkLog)
+                .where(
+                    WorkLog.user_id == retro.user_id,
+                    WorkLog.log_date >= retro.period_from,
+                    WorkLog.log_date <= retro.period_to,
+                )
+                .order_by(WorkLog.log_date)
+            )
+            logs = logs_result.scalars().all()
+
+            if len(logs) < min_log_count:
+                logger.debug("로그 부족으로 스킵 retroId=%s count=%d", retro.id, len(logs))
+                continue
+
+            logs_text = "\n\n".join(
+                f"[{log.log_date}] {log.title}\n{log.content}" for log in logs
+            )
+
+            sample = build_sample(
+                logs_text=logs_text,
+                period_from=str(retro.period_from),
+                period_to=str(retro.period_to),
+                retrospective=retro.content,
+                source="real",
+            )
+            samples.append(sample)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        for sample in samples:
+            f.write(json.dumps(sample.to_dict(), ensure_ascii=False) + "\n")
+
+    logger.info("실제 데이터 %d건 저장 → %s", len(samples), output_path)
+    return len(samples)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DB → Fine-tuning 데이터셋 변환")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("fine_tuning/data/real.jsonl"),
+        help="출력 JSONL 파일 경로",
+    )
+    parser.add_argument(
+        "--min-logs",
+        type=int,
+        default=3,
+        help="샘플로 사용할 최소 WorkLog 수 (기본: 3)",
+    )
+    args = parser.parse_args()
+
+    count = asyncio.run(export_real_samples(args.output, args.min_logs))
+    if count == 0:
+        logger.warning("추출된 샘플이 없습니다. DB에 PUBLISHED 회고가 있는지 확인하세요.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ai/fine_tuning/schema.py
+++ b/apps/ai/fine_tuning/schema.py
@@ -1,0 +1,53 @@
+"""Fine-tuning 데이터셋 스키마 정의.
+
+LLaMA 3 ChatML 형식 (messages format)을 사용합니다.
+"""
+
+from dataclasses import dataclass, field
+
+SYSTEM_PROMPT = """당신은 개발자의 성장을 돕는 AI 코치입니다.
+주어진 작업 로그와 과거 패턴을 바탕으로 진솔하고 통찰력 있는 주간 회고를 작성해주세요.
+회고는 한국어로 작성하며 마크다운 형식을 사용합니다."""
+
+
+@dataclass
+class Message:
+    role: str   # "system" | "user" | "assistant"
+    content: str
+
+
+@dataclass
+class TrainingSample:
+    """학습 샘플 하나 (ChatML messages 형식)"""
+    messages: list[Message]
+    source: str = ""  # "real" | "synthetic"
+
+    def to_dict(self) -> dict:
+        return {
+            "messages": [{"role": m.role, "content": m.content} for m in self.messages],
+            "source": self.source,
+        }
+
+
+def build_sample(logs_text: str, period_from: str, period_to: str, retrospective: str, source: str = "real") -> TrainingSample:
+    """WorkLog 텍스트 + 회고 텍스트로 학습 샘플 생성"""
+    user_content = f"""## 이번 주 작업 로그 ({period_from} ~ {period_to})
+
+{logs_text}
+
+위 내용을 바탕으로 주간 회고를 작성해주세요.
+형식:
+- 제목: 한 줄 요약 (## 제목 형식)
+- 이번 주 한 일
+- 잘한 점
+- 아쉬운 점 & 개선 방향
+- 배운 것"""
+
+    return TrainingSample(
+        messages=[
+            Message(role="system", content=SYSTEM_PROMPT),
+            Message(role="user", content=user_content),
+            Message(role="assistant", content=retrospective),
+        ],
+        source=source,
+    )

--- a/apps/ai/tests/test_fine_tuning.py
+++ b/apps/ai/tests/test_fine_tuning.py
@@ -1,0 +1,195 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from fine_tuning.schema import SYSTEM_PROMPT, TrainingSample, build_sample
+
+
+# ── schema 테스트 ──────────────────────────────────────────────────────────────
+
+def test_build_sample_structure():
+    sample = build_sample(
+        logs_text="[2026-01-06] FastAPI 구현\n내용입니다.",
+        period_from="2026-01-06",
+        period_to="2026-01-10",
+        retrospective="## 이번 주 회고\n열심히 했다.",
+        source="real",
+    )
+
+    assert isinstance(sample, TrainingSample)
+    assert len(sample.messages) == 3
+    assert sample.messages[0].role == "system"
+    assert sample.messages[1].role == "user"
+    assert sample.messages[2].role == "assistant"
+    assert sample.source == "real"
+
+
+def test_build_sample_to_dict():
+    sample = build_sample(
+        logs_text="[2026-01-06] 작업\n내용",
+        period_from="2026-01-06",
+        period_to="2026-01-10",
+        retrospective="## 회고\n내용",
+        source="synthetic",
+    )
+    d = sample.to_dict()
+
+    assert "messages" in d
+    assert d["source"] == "synthetic"
+    assert d["messages"][0]["role"] == "system"
+    assert d["messages"][0]["content"] == SYSTEM_PROMPT
+    assert "2026-01-06" in d["messages"][1]["content"]
+    assert "## 회고" in d["messages"][2]["content"]
+
+
+def test_build_sample_includes_period_in_user_prompt():
+    sample = build_sample(
+        logs_text="작업 내용",
+        period_from="2026-03-01",
+        period_to="2026-03-07",
+        retrospective="회고 내용",
+    )
+    user_content = sample.messages[1].content
+    assert "2026-03-01" in user_content
+    assert "2026-03-07" in user_content
+
+
+# ── build_dataset 테스트 ───────────────────────────────────────────────────────
+
+def _make_valid_sample(assistant_text: str = "## 회고\n" + "내용 " * 50, source: str = "real") -> dict:
+    return {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": "작업 로그 내용"},
+            {"role": "assistant", "content": assistant_text},
+        ],
+        "source": source,
+    }
+
+
+def test_validate_sample_valid():
+    from fine_tuning.build_dataset import validate_sample
+    assert validate_sample(_make_valid_sample()) is True
+
+
+def test_validate_sample_wrong_roles():
+    from fine_tuning.build_dataset import validate_sample
+    sample = _make_valid_sample()
+    sample["messages"][0]["role"] = "user"  # system → user로 변경
+    assert validate_sample(sample) is False
+
+
+def test_validate_sample_too_short():
+    from fine_tuning.build_dataset import validate_sample
+    sample = _make_valid_sample(assistant_text="짧음")
+    assert validate_sample(sample) is False
+
+
+def test_validate_sample_missing_messages():
+    from fine_tuning.build_dataset import validate_sample
+    assert validate_sample({}) is False
+    assert validate_sample({"messages": []}) is False
+
+
+def test_build_final_dataset_train_val_split():
+    from fine_tuning.build_dataset import build_final_dataset
+
+    samples = [_make_valid_sample(f"## 회고{i}\n" + "내용 " * 50) for i in range(20)]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        real_path = tmp_path / "real.jsonl"
+        synthetic_path = tmp_path / "synthetic.jsonl"
+
+        with real_path.open("w") as f:
+            for s in samples[:10]:
+                f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+        with synthetic_path.open("w") as f:
+            for s in samples[10:]:
+                f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+        train_count, val_count = build_final_dataset(
+            real_path=real_path,
+            synthetic_path=synthetic_path,
+            output_dir=tmp_path,
+            val_ratio=0.2,
+            seed=42,
+        )
+
+        assert train_count + val_count == 20
+        assert val_count == 4  # 20 * 0.2
+
+        assert (tmp_path / "train.jsonl").exists()
+        assert (tmp_path / "val.jsonl").exists()
+
+
+def test_build_final_dataset_deduplication():
+    from fine_tuning.build_dataset import build_final_dataset
+
+    same_content = "## 중복 회고\n" + "내용 " * 50
+    samples = [_make_valid_sample(same_content) for _ in range(5)]
+    unique_sample = _make_valid_sample("## 유니크 회고\n" + "다른 내용 " * 50)
+    samples.append(unique_sample)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        real_path = tmp_path / "real.jsonl"
+        synthetic_path = tmp_path / "synthetic.jsonl"
+
+        with real_path.open("w") as f:
+            for s in samples:
+                f.write(json.dumps(s, ensure_ascii=False) + "\n")
+        synthetic_path.write_text("")
+
+        train_count, val_count = build_final_dataset(
+            real_path=real_path,
+            synthetic_path=synthetic_path,
+            output_dir=tmp_path,
+            val_ratio=0.1,
+        )
+
+        assert train_count + val_count == 2  # 중복 5개 → 1개, 유니크 1개
+
+
+# ── generate_synthetic 테스트 ─────────────────────────────────────────────────
+
+async def test_generate_one_sample_success(mocker):
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps({
+        "logs": [
+            {"date": "2026-01-06", "title": "작업1", "content": "내용1입니다. 열심히 했습니다."},
+            {"date": "2026-01-07", "title": "작업2", "content": "내용2입니다. 계속했습니다."},
+        ],
+        "retrospective": "## 이번 주 회고\n" + "내용 " * 100,
+    }))]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    from fine_tuning.generate_synthetic import generate_one_sample, _PERSONAS, _PERIOD_WEEKS
+
+    result = await generate_one_sample(mock_client, _PERSONAS[0], _PERIOD_WEEKS[0])
+
+    assert result is not None
+    assert "messages" in result
+    assert result["source"] == "synthetic"
+
+
+async def test_generate_one_sample_too_short(mocker):
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps({
+        "logs": [{"date": "2026-01-06", "title": "작업", "content": "내용"}],
+        "retrospective": "짧음",
+    }))]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    from fine_tuning.generate_synthetic import generate_one_sample, _PERSONAS, _PERIOD_WEEKS
+
+    result = await generate_one_sample(mock_client, _PERSONAS[0], _PERIOD_WEEKS[0])
+    assert result is None


### PR DESCRIPTION
## Summary
- DB에서 실제 WorkLog+Retrospective 페어를 추출하는 `prepare_dataset.py`
- Claude Haiku API로 다양한 페르소나/기술스택 합성 데이터를 대량 생성하는 `generate_synthetic.py`
- 실제+합성 데이터 병합 → 품질 검증 → 중복 제거 → train/val 분리하는 `build_dataset.py`
- ChatML messages 형식(`TrainingSample`) 스키마 정의

## Closes
Closes #48

## 데이터 파이프라인
```
prepare_dataset.py   →  real.jsonl
generate_synthetic.py →  synthetic.jsonl
                          ↓
                     build_dataset.py
                          ↓
               train.jsonl / val.jsonl  (LLaMA 3 학습 입력)
```

## Test plan
- [ ] `pytest tests/test_fine_tuning.py` — 12개 케이스 통과 확인
- [ ] `python -m fine_tuning.generate_synthetic --count 5` — 합성 데이터 생성 확인
- [ ] `python -m fine_tuning.build_dataset` — train/val 분리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)