### PR TITLE
feat(ai): AI 서버에 Fine-tuned 모델 연동 및 A/B 전환 구현 (#51)

### DIFF
--- a/apps/ai/app/agents/retrospective/nodes.py
+++ b/apps/ai/app/agents/retrospective/nodes.py
@@ -11,6 +11,7 @@ from app.agents.retrospective.state import RetrospectiveState, WorkLogItem
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal, get_mongo_db
 from app.models.work_log import WorkLog
+from app.services.model_service import get_model_service
 from app.services.rag_service import build_rag_context
 
 logger = logging.getLogger(__name__)
@@ -92,29 +93,15 @@ async def generate_draft(state: RetrospectiveState) -> RetrospectiveState:
         for log in state["work_logs"]
     )
 
-    system_prompt = """당신은 개발자의 성장을 돕는 AI 코치입니다.
-주어진 작업 로그와 과거 패턴을 바탕으로 진솔하고 통찰력 있는 주간 회고를 작성해주세요.
-회고는 한국어로 작성하며 마크다운 형식을 사용합니다."""
+    model_service = get_model_service()
+    logger.info("회고 초안 생성 backend=%s", model_service.backend_name)
 
-    human_prompt = f"""## 이번 주 작업 로그 ({state['period_from']} ~ {state['period_to']})
-
-{logs_text}
-
-{f"## 과거 유사 패턴{chr(10)}{state['rag_context']}" if state['rag_context'] else ""}
-
-위 내용을 바탕으로 주간 회고를 작성해주세요.
-형식:
-- 제목: 한 줄 요약 (## 제목 형식)
-- 이번 주 한 일
-- 잘한 점
-- 아쉬운 점 & 개선 방향
-- 배운 것
-"""
-
-    response = await _get_llm().ainvoke(
-        [SystemMessage(content=system_prompt), HumanMessage(content=human_prompt)]
+    full_text = await model_service.generate_retrospective_draft(
+        logs_text=logs_text,
+        period_from=state["period_from"],
+        period_to=state["period_to"],
+        rag_context=state.get("rag_context", ""),
     )
-    full_text = response.content
 
     # 첫 번째 줄을 제목으로 추출
     lines = full_text.strip().split("\n")

--- a/apps/ai/app/core/config.py
+++ b/apps/ai/app/core/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: str = ""
     ANTHROPIC_API_KEY: str = ""
 
+    # Fine-tuned 모델 추론 설정
+    # "claude" → Anthropic Claude (기본), "finetuned" → HF Fine-tuned 모델
+    INFERENCE_BACKEND: str = "claude"
+    HF_MODEL_ID: str = "projectmiluju/grovarc-llama3-8b"
+    HF_TOKEN: str = ""
+
     # JWT (Spring Boot와 동일한 시크릿 사용)
     JWT_SECRET: str = ""
 

--- a/apps/ai/app/services/model_service.py
+++ b/apps/ai/app/services/model_service.py
@@ -1,0 +1,154 @@
+"""통합 모델 추론 서비스.
+
+환경변수 INFERENCE_BACKEND로 백엔드를 선택합니다:
+- "claude"    → Anthropic Claude (기본, API 키 필요)
+- "finetuned" → HF Fine-tuned LLaMA 3 (로컬 GPU 또는 HF Hub)
+
+회고 초안 생성 노드에서 직접 LLM을 호출하는 대신 이 서비스를 사용합니다.
+"""
+
+import asyncio
+import logging
+from functools import lru_cache
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeBackend:
+    """Anthropic Claude 기반 추론 백엔드"""
+
+    def __init__(self) -> None:
+        self._llm = ChatAnthropic(
+            model="claude-sonnet-4-6",
+            api_key=settings.ANTHROPIC_API_KEY,
+            max_tokens=4096,
+        )
+
+    async def generate(self, system_prompt: str, user_prompt: str) -> str:
+        response = await self._llm.ainvoke(
+            [SystemMessage(content=system_prompt), HumanMessage(content=user_prompt)]
+        )
+        return response.content
+
+
+class FinetunedBackend:
+    """HuggingFace Fine-tuned LLaMA 3 기반 추론 백엔드.
+
+    transformers는 선택적 의존성이므로 임포트 실패 시 명확한 오류를 냅니다.
+    """
+
+    def __init__(self) -> None:
+        self._pipe = None
+
+    def _load(self) -> None:
+        """지연 로딩 — 첫 추론 요청 시 모델을 로드합니다."""
+        if self._pipe is not None:
+            return
+
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+        except ImportError as e:
+            raise ImportError(
+                "transformers / torch 패키지가 필요합니다. "
+                "pip install transformers torch accelerate 를 실행하세요."
+            ) from e
+
+        logger.info("Fine-tuned 모델 로드 중: %s", settings.HF_MODEL_ID)
+        tokenizer = AutoTokenizer.from_pretrained(
+            settings.HF_MODEL_ID,
+            token=settings.HF_TOKEN or None,
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            settings.HF_MODEL_ID,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            token=settings.HF_TOKEN or None,
+        )
+        self._pipe = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+            device_map="auto",
+        )
+        logger.info("Fine-tuned 모델 로드 완료")
+
+    async def generate(self, system_prompt: str, user_prompt: str) -> str:
+        self._load()
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        # transformers pipeline은 동기 → asyncio executor로 실행
+        loop = asyncio.get_event_loop()
+        output = await loop.run_in_executor(
+            None,
+            lambda: self._pipe(
+                messages,
+                max_new_tokens=1024,
+                do_sample=True,
+                temperature=0.7,
+                top_p=0.9,
+            ),
+        )
+        return output[0]["generated_text"][-1]["content"]
+
+
+class ModelService:
+    """INFERENCE_BACKEND 설정에 따라 백엔드를 선택하는 통합 추론 서비스"""
+
+    def __init__(self) -> None:
+        backend = settings.INFERENCE_BACKEND.lower()
+        if backend == "finetuned":
+            self._backend = FinetunedBackend()
+            logger.info("추론 백엔드: Fine-tuned LLaMA 3 (%s)", settings.HF_MODEL_ID)
+        else:
+            self._backend = ClaudeBackend()
+            logger.info("추론 백엔드: Claude (claude-sonnet-4-6)")
+
+    async def generate_retrospective_draft(
+        self,
+        logs_text: str,
+        period_from: str,
+        period_to: str,
+        rag_context: str = "",
+    ) -> str:
+        """주간 회고 초안 생성.
+
+        Returns:
+            마크다운 형식의 회고 초안 전문
+        """
+        system_prompt = (
+            "당신은 개발자의 성장을 돕는 AI 코치입니다.\n"
+            "주어진 작업 로그와 과거 패턴을 바탕으로 진솔하고 통찰력 있는 주간 회고를 작성해주세요.\n"
+            "회고는 한국어로 작성하며 마크다운 형식을 사용합니다."
+        )
+        user_prompt = (
+            f"## 이번 주 작업 로그 ({period_from} ~ {period_to})\n\n"
+            f"{logs_text}\n\n"
+            f"{f'## 과거 유사 패턴{chr(10)}{rag_context}{chr(10)}{chr(10)}' if rag_context else ''}"
+            "위 내용을 바탕으로 주간 회고를 작성해주세요.\n"
+            "형식:\n"
+            "- 제목: 한 줄 요약 (## 제목 형식)\n"
+            "- 이번 주 한 일\n"
+            "- 잘한 점\n"
+            "- 아쉬운 점 & 개선 방향\n"
+            "- 배운 것"
+        )
+        return await self._backend.generate(system_prompt, user_prompt)
+
+    @property
+    def backend_name(self) -> str:
+        return "finetuned" if isinstance(self._backend, FinetunedBackend) else "claude"
+
+
+@lru_cache(maxsize=1)
+def get_model_service() -> ModelService:
+    """싱글턴 ModelService 반환"""
+    return ModelService()

--- a/apps/ai/tests/test_model_service.py
+++ b/apps/ai/tests/test_model_service.py
@@ -1,0 +1,201 @@
+"""ModelService A/B 백엔드 전환 테스트."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── ClaudeBackend ─────────────────────────────────────────────────────────────
+
+async def test_claude_backend_generate(mocker):
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="## 회고\n내용입니다."))
+    mocker.patch("app.services.model_service.ChatAnthropic", return_value=mock_llm)
+
+    from app.services.model_service import ClaudeBackend
+    backend = ClaudeBackend()
+    result = await backend.generate("시스템 프롬프트", "유저 프롬프트")
+
+    assert result == "## 회고\n내용입니다."
+    mock_llm.ainvoke.assert_called_once()
+
+
+# ── FinetunedBackend ──────────────────────────────────────────────────────────
+
+def test_finetuned_backend_raises_without_transformers(mocker):
+    """transformers 없을 때 ImportError 발생"""
+    mocker.patch.dict("sys.modules", {"torch": None, "transformers": None})
+
+    from app.services.model_service import FinetunedBackend
+    backend = FinetunedBackend()
+
+    with pytest.raises(ImportError, match="transformers"):
+        backend._load()
+
+
+async def test_finetuned_backend_generate(mocker):
+    """transformers pipeline 모킹 후 추론"""
+    mock_pipe = MagicMock(return_value=[
+        {"generated_text": [
+            {"role": "system", "content": "..."},
+            {"role": "user", "content": "..."},
+            {"role": "assistant", "content": "## Fine-tuned 회고\n내용"},
+        ]}
+    ])
+
+    mock_torch = MagicMock()
+    mock_torch.bfloat16 = "bfloat16"
+
+    mock_transformers = MagicMock()
+    mock_transformers.AutoTokenizer.from_pretrained.return_value = MagicMock()
+    mock_transformers.AutoModelForCausalLM.from_pretrained.return_value = MagicMock()
+    mock_transformers.pipeline.return_value = mock_pipe
+
+    mocker.patch.dict("sys.modules", {
+        "torch": mock_torch,
+        "transformers": mock_transformers,
+    })
+
+    from app.services.model_service import FinetunedBackend
+    backend = FinetunedBackend()
+    result = await backend.generate("시스템", "유저")
+
+    assert "Fine-tuned 회고" in result
+
+
+# ── ModelService (통합) ───────────────────────────────────────────────────────
+
+async def test_model_service_uses_claude_by_default(mocker):
+    mocker.patch("app.services.model_service.settings.INFERENCE_BACKEND", "claude")
+    mocker.patch("app.services.model_service.settings.ANTHROPIC_API_KEY", "dummy")
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="## 클로드 회고\n내용"))
+    mocker.patch("app.services.model_service.ChatAnthropic", return_value=mock_llm)
+
+    from app.services.model_service import ModelService
+    service = ModelService()
+
+    assert service.backend_name == "claude"
+
+    result = await service.generate_retrospective_draft(
+        logs_text="[2026-03-28] 작업\n내용",
+        period_from="2026-03-28",
+        period_to="2026-04-03",
+    )
+    assert "클로드 회고" in result
+
+
+async def test_model_service_uses_finetuned_when_configured(mocker):
+    mocker.patch("app.services.model_service.settings.INFERENCE_BACKEND", "finetuned")
+    mocker.patch("app.services.model_service.settings.HF_MODEL_ID", "projectmiluju/grovarc-llama3-8b")
+    mocker.patch("app.services.model_service.settings.HF_TOKEN", "dummy")
+
+    mock_backend = AsyncMock()
+    mock_backend.generate = AsyncMock(return_value="## Fine-tuned 회고\n내용")
+
+    mocker.patch("app.services.model_service.FinetunedBackend", return_value=mock_backend)
+
+    from app.services.model_service import ModelService
+    service = ModelService()
+
+    assert service.backend_name == "finetuned"
+
+    result = await service.generate_retrospective_draft(
+        logs_text="[2026-03-28] 작업\n내용",
+        period_from="2026-03-28",
+        period_to="2026-04-03",
+        rag_context="관련 과거 패턴",
+    )
+    assert "Fine-tuned 회고" in result
+
+
+async def test_model_service_prompt_includes_rag_context(mocker):
+    """rag_context가 있을 때 유저 프롬프트에 포함되는지 확인"""
+    mocker.patch("app.services.model_service.settings.INFERENCE_BACKEND", "claude")
+    mocker.patch("app.services.model_service.settings.ANTHROPIC_API_KEY", "dummy")
+
+    captured_prompt = {}
+
+    async def capture_generate(system_prompt, user_prompt):
+        captured_prompt["user"] = user_prompt
+        return "## 회고\n내용"
+
+    mock_backend = MagicMock()
+    mock_backend.generate = capture_generate
+    mocker.patch("app.services.model_service.ClaudeBackend", return_value=mock_backend)
+
+    from app.services.model_service import ModelService
+    service = ModelService()
+    await service.generate_retrospective_draft(
+        logs_text="로그 내용",
+        period_from="2026-03-28",
+        period_to="2026-04-03",
+        rag_context="## 관련 작업 로그\n과거 패턴",
+    )
+
+    assert "관련 작업 로그" in captured_prompt["user"]
+
+
+async def test_model_service_prompt_excludes_rag_when_empty(mocker):
+    """rag_context 없을 때 프롬프트에 RAG 섹션 미포함 확인"""
+    mocker.patch("app.services.model_service.settings.INFERENCE_BACKEND", "claude")
+    mocker.patch("app.services.model_service.settings.ANTHROPIC_API_KEY", "dummy")
+
+    captured_prompt = {}
+
+    async def capture_generate(system_prompt, user_prompt):
+        captured_prompt["user"] = user_prompt
+        return "## 회고\n내용"
+
+    mock_backend = MagicMock()
+    mock_backend.generate = capture_generate
+    mocker.patch("app.services.model_service.ClaudeBackend", return_value=mock_backend)
+
+    from app.services.model_service import ModelService
+    service = ModelService()
+    await service.generate_retrospective_draft(
+        logs_text="로그 내용",
+        period_from="2026-03-28",
+        period_to="2026-04-03",
+        rag_context="",
+    )
+
+    assert "과거 유사 패턴" not in captured_prompt["user"]
+
+
+# ── generate_draft 노드 연동 ──────────────────────────────────────────────────
+
+async def test_generate_draft_node_uses_model_service(mocker):
+    """retrospective nodes의 generate_draft가 model_service를 사용하는지 확인"""
+    mock_service = AsyncMock()
+    mock_service.backend_name = "claude"
+    mock_service.generate_retrospective_draft = AsyncMock(
+        return_value="## 노드 테스트 회고\n내용입니다."
+    )
+    mocker.patch("app.agents.retrospective.nodes.get_model_service", return_value=mock_service)
+
+    from app.agents.retrospective.nodes import generate_draft
+    from app.agents.retrospective.state import RetrospectiveState
+
+    state = RetrospectiveState(
+        user_id="user-123",
+        period_from="2026-03-28",
+        period_to="2026-04-03",
+        work_logs=[
+            {"id": "1", "title": "작업", "content": "내용", "log_date": "2026-03-28", "mood": None}
+        ],
+        rag_context="",
+        analysis_summary="",
+        draft_title="",
+        draft_content="",
+        goals=[],
+        mongo_doc_id=None,
+        error=None,
+    )
+
+    result = await generate_draft(state)
+
+    assert result["draft_content"] == "## 노드 테스트 회고\n내용입니다."
+    assert result["draft_title"] == "노드 테스트 회고"
+    mock_service.generate_retrospective_draft.assert_called_once()


### PR DESCRIPTION
## Summary
- `model_service.py`: Claude / Fine-tuned 모델 백엔드 추상화, 환경변수 한 줄로 전환
- `retrospective/nodes.py`: `generate_draft` 노드를 `model_service` 기반으로 교체
- `config.py`: `INFERENCE_BACKEND`, `HF_MODEL_ID`, `HF_TOKEN` 환경변수 추가

## Closes
Closes #51

## A/B 전환 방법
```env
# Claude 사용 (기본)
INFERENCE_BACKEND=claude

# Fine-tuned LLaMA 3 사용
INFERENCE_BACKEND=finetuned
HF_MODEL_ID=projectmiluju/grovarc-llama3-8b
HF_TOKEN=hf_xxx
```

## 아키텍처
```
generate_draft (node)
    └── ModelService.generate_retrospective_draft()
            ├── INFERENCE_BACKEND=claude    → ClaudeBackend (Anthropic API)
            └── INFERENCE_BACKEND=finetuned → FinetunedBackend (transformers pipeline)
```

## Test plan
- [ ] `pytest tests/test_model_service.py` — 8개 케이스 통과
- [ ] `INFERENCE_BACKEND=claude` 로 주간 회고 Agent 실행 → Claude 응답 확인
- [ ] `INFERENCE_BACKEND=finetuned` 로 전환 후 Fine-tuned 모델 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)