### PR TITLE
feat(web): Next.js 14 프로젝트 초기 세팅 (#56)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,9 @@
+# Spring Boot API 서버 URL
+NEXT_PUBLIC_API_URL=http://localhost:8080
+
+# AI 서버 URL
+NEXT_PUBLIC_AI_URL=http://localhost:8000
+
+# Next.js
+NEXTAUTH_SECRET=your-secret-here
+NEXTAUTH_URL=http://localhost:3000

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "warn"
+  }
+}

--- a/apps/web/.prettierrc
+++ b/apps/web/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,18 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+  images: {
+    domains: [],
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/api/v1/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/api/v1/:path*`,
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "grovarc-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "axios": "^1.7.0",
+    "zustand": "^4.5.0",
+    "react-hook-form": "^7.52.0",
+    "@hookform/resolvers": "^3.9.0",
+    "zod": "^3.23.0",
+    "react-markdown": "^9.0.0",
+    "recharts": "^2.12.0",
+    "date-fns": "^3.6.0",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.3.0",
+    "lucide-react": "^0.400.0",
+    "next-themes": "^0.3.0",
+    "@radix-ui/react-dialog": "^1.1.0",
+    "@radix-ui/react-dropdown-menu": "^2.1.0",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-select": "^2.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "prettier": "^3.3.0",
+    "prettier-plugin-tailwindcss": "^0.6.0",
+    "@playwright/test": "^1.45.0"
+  }
+}

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,55 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { ThemeProvider } from "next-themes";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Grovarc — 개발자 성장 트래커",
+  description: "매일 작업 로그를 기록하면 AI가 회고 초안과 성장 로드맵을 자동으로 만들어줍니다.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ko" suppressHydrationWarning>
+      <body className={inter.className}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tight">Grovarc</h1>
+        <p className="mt-3 text-lg text-muted-foreground">
+          매일 작업 로그를 기록하면 AI가 회고 초안과 성장 로드맵을 만들어줍니다.
+        </p>
+      </div>
+      <div className="flex gap-4">
+        <Link
+          href="/login"
+          className="rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          로그인
+        </Link>
+        <Link
+          href="/signup"
+          className="rounded-md border border-input px-6 py-2.5 text-sm font-medium hover:bg-accent"
+        >
+          회원가입
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/hooks/useToast.ts
+++ b/apps/web/src/hooks/useToast.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback } from "react";
+
+interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: "default" | "destructive";
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const toast = useCallback(
+    ({ title, description, variant = "default" }: Omit<Toast, "id">) => {
+      const id = Math.random().toString(36).slice(2);
+      setToasts((prev) => [...prev, { id, title, description, variant }]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 4000);
+    },
+    [],
+  );
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { toasts, toast, dismiss };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,77 @@
+import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
+import { useAuthStore } from "@/store/authStore";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080",
+  timeout: 10_000,
+  headers: { "Content-Type": "application/json" },
+});
+
+// 요청 인터셉터 — Access Token 자동 첨부
+api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = useAuthStore.getState().accessToken;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 응답 인터셉터 — 401 시 Refresh Token으로 재발급
+let isRefreshing = false;
+let pendingQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (err: unknown) => void;
+}> = [];
+
+const processPendingQueue = (token: string | null, error: unknown = null) => {
+  pendingQueue.forEach(({ resolve, reject }) => {
+    if (token) resolve(token);
+    else reject(error);
+  });
+  pendingQueue = [];
+};
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          pendingQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return api(originalRequest);
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const { data } = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/refresh`,
+          {},
+          { withCredentials: true }, // httpOnly 쿠키로 Refresh Token 전송
+        );
+        const newToken: string = data.accessToken;
+        useAuthStore.getState().setAccessToken(newToken);
+        processPendingQueue(newToken);
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        processPendingQueue(null, refreshError);
+        useAuthStore.getState().logout();
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PUBLIC_PATHS = ["/", "/login", "/signup"];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 공개 경로는 통과
+  if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith("/api"))) {
+    return NextResponse.next();
+  }
+
+  // 정적 파일, Next.js 내부 경로 통과
+  if (pathname.startsWith("/_next") || pathname.includes(".")) {
+    return NextResponse.next();
+  }
+
+  // grovarc-auth 쿠키로 로그인 여부 확인 (서버 사이드)
+  const authCookie = request.cookies.get("grovarc-auth");
+  if (!authCookie) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/web/src/store/authStore.ts
+++ b/apps/web/src/store/authStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthState {
+  accessToken: string | null;
+  user: { id: string; email: string; nickname: string } | null;
+  setAccessToken: (token: string) => void;
+  setUser: (user: AuthState["user"]) => void;
+  logout: () => void;
+  isAuthenticated: () => boolean;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      user: null,
+
+      setAccessToken: (token) => set({ accessToken: token }),
+
+      setUser: (user) => set({ user }),
+
+      logout: () => set({ accessToken: null, user: null }),
+
+      isAuthenticated: () => !!get().accessToken,
+    }),
+    {
+      name: "grovarc-auth",
+      // accessToken은 세션 스토리지에만 저장 (탭 닫으면 삭제)
+      partialize: (state) => ({ user: state.user }),
+    },
+  ),
+);

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,0 +1,98 @@
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignupRequest {
+  email: string;
+  password: string;
+  nickname: string;
+}
+
+export interface TokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  nickname: string;
+  createdAt: string;
+}
+
+// ── WorkLog ───────────────────────────────────────────────────────────────────
+
+export type Mood = "GREAT" | "GOOD" | "NEUTRAL" | "BAD" | "TERRIBLE";
+
+export interface WorkLog {
+  id: string;
+  title: string;
+  content: string;
+  logDate: string;    // "YYYY-MM-DD"
+  mood: Mood | null;
+  tags: Tag[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkLogRequest {
+  title: string;
+  content: string;
+  logDate: string;
+  mood?: Mood;
+  tagIds?: string[];
+}
+
+// ── Tag ───────────────────────────────────────────────────────────────────────
+
+export interface Tag {
+  id: string;
+  name: string;
+}
+
+// ── Retrospective ─────────────────────────────────────────────────────────────
+
+export type RetroStatus = "DRAFT" | "PUBLISHED";
+
+export interface Retrospective {
+  id: string;
+  title: string;
+  content: string;
+  periodFrom: string;
+  periodTo: string;
+  status: RetroStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Dashboard ─────────────────────────────────────────────────────────────────
+
+export interface DashboardStats {
+  totalLogs: number;
+  totalRetrospectives: number;
+  currentStreak: number;
+  longestStreak: number;
+  weeklyLogCounts: { date: string; count: number }[];
+}
+
+// ── Coaching ──────────────────────────────────────────────────────────────────
+
+export interface CoachingResult {
+  weakStacks: string[];
+  roadmap: string;
+  mongoDocId: string | null;
+  createdAt: string;
+}
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,53 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Next.js 14 App Router + TypeScript + TailwindCSS + shadcn/ui CSS 변수 구성
- axios API 클라이언트: JWT 자동 첨부 + 401 Refresh Token 재발급 인터셉터 (큐 처리)
- Zustand authStore: accessToken 메모리 보관, user 정보 persist
- Next.js middleware: 보호 경로 접근 시 /login 리다이렉트

## Closes
Closes #56

## 파일 구조
```
apps/web/src/
├── app/
│   ├── layout.tsx     # RootLayout (ThemeProvider)
│   ├── page.tsx       # 랜딩 페이지
│   └── globals.css    # TailwindCSS + CSS 변수
├── lib/
│   ├── api.ts         # axios 클라이언트 + 인터셉터
│   └── utils.ts       # cn() 유틸리티
├── store/
│   └── authStore.ts   # Zustand 인증 상태
├── types/
│   └── index.ts       # 전체 타입 정의
├── hooks/
│   └── useToast.ts
└── middleware.ts      # 인증 미들웨어
```

## Test plan
- [ ] `bun install && bun run dev` — 로컬 개발 서버 실행 확인
- [ ] `bun run build` — 빌드 성공 확인
- [ ] `bun run lint` — ESLint 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)