### PR TITLE
feat(web): 인증 페이지 구현 (회원가입/로그인) (#57)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "date-fns": "^3.6.0",
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.3.0",
+    "class-variance-authority": "^0.7.0",
     "lucide-react": "^0.400.0",
     "next-themes": "^0.3.0",
     "@radix-ui/react-dialog": "^1.1.0",

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { login } from "@/lib/auth";
+
+const schema = z.object({
+  email: z.string().email("올바른 이메일을 입력하세요"),
+  password: z.string().min(8, "비밀번호는 8자 이상이어야 합니다"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect") ?? "/dashboard";
+  const [serverError, setServerError] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      setServerError("");
+      await login(values);
+      router.replace(redirect);
+    } catch {
+      setServerError("이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Grovarc</h1>
+          <p className="mt-1 text-sm text-muted-foreground">로그인하여 성장을 기록하세요</p>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="email">이메일</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="dev@example.com"
+              autoComplete="email"
+              {...register("email")}
+            />
+            {errors.email && (
+              <p className="text-xs text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              autoComplete="current-password"
+              {...register("password")}
+            />
+            {errors.password && (
+              <p className="text-xs text-destructive">{errors.password.message}</p>
+            )}
+          </div>
+
+          {serverError && (
+            <p className="text-center text-sm text-destructive">{serverError}</p>
+          )}
+
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "로그인 중..." : "로그인"}
+          </Button>
+        </form>
+
+        <p className="text-center text-sm text-muted-foreground">
+          계정이 없으신가요?{" "}
+          <Link href="/signup" className="font-medium text-primary hover:underline">
+            회원가입
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signup, login } from "@/lib/auth";
+
+const schema = z
+  .object({
+    email: z.string().email("올바른 이메일을 입력하세요"),
+    nickname: z.string().min(2, "닉네임은 2자 이상이어야 합니다").max(20, "닉네임은 20자 이하"),
+    password: z.string().min(8, "비밀번호는 8자 이상이어야 합니다"),
+    passwordConfirm: z.string(),
+  })
+  .refine((d) => d.password === d.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  });
+
+type FormValues = z.infer<typeof schema>;
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async ({ email, password, nickname }: FormValues) => {
+    try {
+      setServerError("");
+      await signup({ email, password, nickname });
+      await login({ email, password });
+      router.replace("/dashboard");
+    } catch {
+      setServerError("회원가입에 실패했습니다. 이미 사용 중인 이메일일 수 있습니다.");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Grovarc</h1>
+          <p className="mt-1 text-sm text-muted-foreground">개발자 성장 트래커 시작하기</p>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="email">이메일</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="dev@example.com"
+              autoComplete="email"
+              {...register("email")}
+            />
+            {errors.email && (
+              <p className="text-xs text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="nickname">닉네임</Label>
+            <Input
+              id="nickname"
+              placeholder="개발자닉네임"
+              autoComplete="nickname"
+              {...register("nickname")}
+            />
+            {errors.nickname && (
+              <p className="text-xs text-destructive">{errors.nickname.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              autoComplete="new-password"
+              {...register("password")}
+            />
+            {errors.password && (
+              <p className="text-xs text-destructive">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
+            <Input
+              id="passwordConfirm"
+              type="password"
+              placeholder="••••••••"
+              autoComplete="new-password"
+              {...register("passwordConfirm")}
+            />
+            {errors.passwordConfirm && (
+              <p className="text-xs text-destructive">{errors.passwordConfirm.message}</p>
+            )}
+          </div>
+
+          {serverError && (
+            <p className="text-center text-sm text-destructive">{serverError}</p>
+          )}
+
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "가입 중..." : "회원가입"}
+          </Button>
+        </form>
+
+        <p className="text-center text-sm text-muted-foreground">
+          이미 계정이 있으신가요?{" "}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background",
+          "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+          "placeholder:text-muted-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,23 @@
+import api from "./api";
+import { useAuthStore } from "@/store/authStore";
+import type { LoginRequest, SignupRequest, TokenResponse, User } from "@/types";
+
+export async function login(body: LoginRequest): Promise<void> {
+  const { data } = await api.post<TokenResponse>("/api/v1/auth/login", body);
+  useAuthStore.getState().setAccessToken(data.accessToken);
+
+  const { data: user } = await api.get<User>("/api/v1/users/me");
+  useAuthStore.getState().setUser(user);
+}
+
+export async function signup(body: SignupRequest): Promise<void> {
+  await api.post("/api/v1/auth/signup", body);
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await api.post("/api/v1/auth/logout");
+  } finally {
+    useAuthStore.getState().logout();
+  }
+}


### PR DESCRIPTION
## Summary
- `/login`: react-hook-form + zod 유효성 검증, 로그인 성공 시 redirect 파라미터 경로로 이동
- `/signup`: 비밀번호 확인 검증, 가입 후 자동 로그인 → `/dashboard` 이동
- `lib/auth.ts`: login / signup / logout API 래퍼 + authStore 상태 동기화
- shadcn/ui 스타일 Button / Input / Label 기본 컴포넌트

## Closes
Closes #57

## Test plan
- [ ] 로그인 성공 → `/dashboard` 이동
- [ ] 로그인 실패 → 에러 메시지 표시
- [ ] 회원가입 → 자동 로그인 → `/dashboard` 이동
- [ ] 미인증 상태로 `/dashboard` 접근 → `/login?redirect=/dashboard` 리다이렉트

🤖 Generated with [Claude Code](https://claude.com/claude-code)