### PR TITLE
feat(web): 대시보드 페이지 구현 (#58)

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/DashboardContent.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/DashboardContent.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { StatCard } from "@/components/dashboard/StatCard";
+import { StreakCalendar } from "@/components/dashboard/StreakCalendar";
+import { WeeklyChart } from "@/components/dashboard/WeeklyChart";
+import api from "@/lib/api";
+import type { DashboardStats, Retrospective } from "@/types";
+
+export function DashboardContent() {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [recentRetros, setRecentRetros] = useState<Retrospective[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      api.get<DashboardStats>("/api/v1/dashboard"),
+      api.get<{ content: Retrospective[] }>("/api/v1/retrospectives?size=3&status=PUBLISHED"),
+    ])
+      .then(([statsRes, retrosRes]) => {
+        setStats(statsRes.data);
+        setRecentRetros(retrosRes.data.content);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading || !stats) return null;
+
+  // 스트릭 캘린더용 날짜 추출 (weeklyLogCounts에서)
+  const activeDates = stats.weeklyLogCounts
+    .filter((d) => d.count > 0)
+    .map((d) => d.date);
+
+  return (
+    <div className="space-y-6">
+      {/* 통계 카드 */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="총 로그" value={stats.totalLogs} sub="누적" />
+        <StatCard label="총 회고" value={stats.totalRetrospectives} sub="누적" />
+        <StatCard
+          label="현재 스트릭"
+          value={`${stats.currentStreak}일`}
+          sub="연속 작성"
+        />
+        <StatCard
+          label="최장 스트릭"
+          value={`${stats.longestStreak}일`}
+          sub="역대 최장"
+        />
+      </div>
+
+      {/* 캘린더 + 차트 */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <StreakCalendar activeDates={activeDates} />
+        <WeeklyChart data={stats.weeklyLogCounts.slice(-7)} />
+      </div>
+
+      {/* 최근 회고 */}
+      {recentRetros.length > 0 && (
+        <div className="rounded-lg border bg-card p-5">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-medium">최근 회고</h3>
+            <Link href="/retrospectives" className="text-xs text-muted-foreground hover:underline">
+              전체 보기
+            </Link>
+          </div>
+          <ul className="space-y-2">
+            {recentRetros.map((retro) => (
+              <li key={retro.id}>
+                <Link
+                  href={`/retrospectives/${retro.id}`}
+                  className="flex items-center justify-between rounded-md p-2 hover:bg-accent"
+                >
+                  <span className="text-sm font-medium">{retro.title}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {format(new Date(retro.periodFrom), "M/d")} ~{" "}
+                    {format(new Date(retro.periodTo), "M/d")}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import { DashboardContent } from "./DashboardContent";
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">대시보드</h1>
+      <Suspense fallback={<DashboardSkeleton />}>
+        <DashboardContent />
+      </Suspense>
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="h-48 animate-pulse rounded-lg bg-muted" />
+        <div className="h-48 animate-pulse rounded-lg bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,10 @@
+import { Sidebar } from "@/components/layout/Sidebar";
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <main className="flex-1 overflow-y-auto p-6">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/StatCard.tsx
+++ b/apps/web/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+interface StatCardProps {
+  label: string;
+  value: number | string;
+  sub?: string;
+  className?: string;
+}
+
+export function StatCard({ label, value, sub, className }: StatCardProps) {
+  return (
+    <div className={cn("rounded-lg border bg-card p-5", className)}>
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-3xl font-bold">{value}</p>
+      {sub && <p className="mt-1 text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/StreakCalendar.tsx
+++ b/apps/web/src/components/dashboard/StreakCalendar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+import { eachDayOfInterval, subDays, format, isSameDay } from "date-fns";
+import { cn } from "@/lib/utils";
+
+interface StreakCalendarProps {
+  activeDates: string[]; // "YYYY-MM-DD" 배열
+}
+
+export function StreakCalendar({ activeDates }: StreakCalendarProps) {
+  const today = new Date();
+  const days = useMemo(
+    () => eachDayOfInterval({ start: subDays(today, 6 * 7 - 1), end: today }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const activeSet = useMemo(() => new Set(activeDates), [activeDates]);
+
+  // 7행(요일) x N열(주) 그리드
+  const weeks: Date[][] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h3 className="mb-4 text-sm font-medium">최근 6주 활동</h3>
+      <div className="flex gap-1">
+        {weeks.map((week, wi) => (
+          <div key={wi} className="flex flex-col gap-1">
+            {week.map((day) => {
+              const key = format(day, "yyyy-MM-dd");
+              const active = activeSet.has(key);
+              const isToday = isSameDay(day, today);
+              return (
+                <div
+                  key={key}
+                  title={key}
+                  className={cn(
+                    "h-4 w-4 rounded-sm",
+                    active ? "bg-primary" : "bg-muted",
+                    isToday && !active && "ring-1 ring-primary",
+                  )}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="h-3 w-3 rounded-sm bg-muted" />
+        <span>없음</span>
+        <div className="h-3 w-3 rounded-sm bg-primary" />
+        <span>작성</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/WeeklyChart.tsx
+++ b/apps/web/src/components/dashboard/WeeklyChart.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { format, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+
+interface WeeklyChartProps {
+  data: { date: string; count: number }[];
+}
+
+export function WeeklyChart({ data }: WeeklyChartProps) {
+  const chartData = data.map((d) => ({
+    ...d,
+    label: format(parseISO(d.date), "M/d", { locale: ko }),
+  }));
+
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h3 className="mb-4 text-sm font-medium">최근 7일 작성 현황</h3>
+      <ResponsiveContainer width="100%" height={140}>
+        <BarChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+          <XAxis dataKey="label" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fontSize: 12 }} allowDecimals={false} axisLine={false} tickLine={false} />
+          <Tooltip
+            cursor={{ fill: "hsl(var(--accent))" }}
+            contentStyle={{
+              background: "hsl(var(--card))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: "6px",
+              fontSize: "12px",
+            }}
+            formatter={(v: number) => [`${v}개`, "로그"]}
+          />
+          <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+            {chartData.map((entry, i) => (
+              <Cell
+                key={i}
+                fill={entry.count > 0 ? "hsl(var(--primary))" : "hsl(var(--muted))"}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  BookOpen,
+  FileText,
+  TrendingUp,
+  LogOut,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { logout } from "@/lib/auth";
+import { useRouter } from "next/navigation";
+
+const navItems = [
+  { href: "/dashboard", label: "대시보드", icon: LayoutDashboard },
+  { href: "/logs", label: "작업 로그", icon: BookOpen },
+  { href: "/retrospectives", label: "회고", icon: FileText },
+  { href: "/coaching", label: "성장 코칭", icon: TrendingUp },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await logout();
+    router.push("/login");
+  };
+
+  return (
+    <aside className="flex h-screen w-56 flex-col border-r bg-card px-3 py-4">
+      <div className="mb-6 px-3">
+        <span className="text-lg font-bold">Grovarc</span>
+      </div>
+
+      <nav className="flex flex-1 flex-col gap-1">
+        {navItems.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              pathname === href || pathname.startsWith(href + "/")
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </Link>
+        ))}
+      </nav>
+
+      <button
+        onClick={handleLogout}
+        className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <LogOut className="h-4 w-4" />
+        로그아웃
+      </button>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- Sidebar 공통 레이아웃 (대시보드/로그/회고/코칭 네비게이션 + 로그아웃)
- 통계 카드 4개 (총 로그, 총 회고, 현재 스트릭, 최장 스트릭)
- GitHub 잔디 스타일 6주 활동 캘린더 (date-fns)
- 7일 바 차트 (recharts)
- 최근 PUBLISHED 회고 3개 미리보기
- Suspense 기반 스켈레톤 로딩

## Closes
Closes #58

## Test plan
- [ ] `/dashboard` 접근 → 통계/캘린더/차트 렌더링 확인
- [ ] Sidebar 네비게이션 active 상태 확인
- [ ] 스켈레톤 로딩 → 데이터 로드 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)