### PR TITLE
feat(web): 작업 로그 페이지 구현 (목록/작성/상세) (#59)

### DIFF
--- a/apps/web/src/components/worklog/MoodSelector.tsx
+++ b/apps/web/src/components/worklog/MoodSelector.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { Mood } from "@/types";
+
+const MOODS: { value: Mood; emoji: string; label: string }[] = [
+  { value: "GREAT", emoji: "🚀", label: "최고" },
+  { value: "GOOD", emoji: "😊", label: "좋음" },
+  { value: "NEUTRAL", emoji: "😐", label: "보통" },
+  { value: "BAD", emoji: "😔", label: "나쁨" },
+  { value: "TERRIBLE", emoji: "😩", label: "최악" },
+];
+
+interface MoodSelectorProps {
+  value?: Mood;
+  onChange: (mood: Mood) => void;
+}
+
+export function MoodSelector({ value, onChange }: MoodSelectorProps) {
+  return (
+    <div className="flex gap-2">
+      {MOODS.map((m) => (
+        <button
+          key={m.value}
+          type="button"
+          onClick={() => onChange(m.value)}
+          title={m.label}
+          className={cn(
+            "flex h-10 w-10 items-center justify-center rounded-full text-xl transition-all",
+            value === m.value
+              ? "ring-2 ring-primary ring-offset-2 scale-110"
+              : "opacity-50 hover:opacity-100",
+          )}
+        >
+          {m.emoji}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/worklog/TagInput.tsx
+++ b/apps/web/src/components/worklog/TagInput.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getTags } from "@/lib/worklog";
+import type { Tag } from "@/types";
+
+interface TagInputProps {
+  selected: Tag[];
+  onChange: (tags: Tag[]) => void;
+}
+
+export function TagInput({ selected, onChange }: TagInputProps) {
+  const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    getTags().then(setAllTags).catch(() => {});
+  }, []);
+
+  const filtered = allTags.filter(
+    (t) =>
+      t.name.toLowerCase().includes(query.toLowerCase()) &&
+      !selected.some((s) => s.id === t.id),
+  );
+
+  const add = (tag: Tag) => {
+    onChange([...selected, tag]);
+    setQuery("");
+    setOpen(false);
+  };
+
+  const remove = (id: string) => {
+    onChange(selected.filter((t) => t.id !== id));
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2">
+        {selected.map((tag) => (
+          <span
+            key={tag.id}
+            className="flex items-center gap-1 rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium"
+          >
+            {tag.name}
+            <button type="button" onClick={() => remove(tag.id)}>
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          className="flex-1 min-w-20 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          placeholder={selected.length === 0 ? "태그 검색..." : ""}
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+        />
+      </div>
+
+      {open && filtered.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-full rounded-md border bg-card shadow-md">
+          {filtered.slice(0, 8).map((tag) => (
+            <li key={tag.id}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
+                onMouseDown={() => add(tag)}
+              >
+                {tag.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/worklog.ts
+++ b/apps/web/src/lib/worklog.ts
@@ -1,0 +1,40 @@
+import api from "./api";
+import type { WorkLog, CreateWorkLogRequest, PageResponse } from "@/types";
+
+export async function getWorkLogs(params?: {
+  page?: number;
+  size?: number;
+  tagId?: string;
+  from?: string;
+  to?: string;
+}): Promise<PageResponse<WorkLog>> {
+  const { data } = await api.get<PageResponse<WorkLog>>("/api/v1/work-logs", { params });
+  return data;
+}
+
+export async function getWorkLog(id: string): Promise<WorkLog> {
+  const { data } = await api.get<WorkLog>(`/api/v1/work-logs/${id}`);
+  return data;
+}
+
+export async function createWorkLog(body: CreateWorkLogRequest): Promise<WorkLog> {
+  const { data } = await api.post<WorkLog>("/api/v1/work-logs", body);
+  return data;
+}
+
+export async function updateWorkLog(
+  id: string,
+  body: Partial<CreateWorkLogRequest>,
+): Promise<WorkLog> {
+  const { data } = await api.put<WorkLog>(`/api/v1/work-logs/${id}`, body);
+  return data;
+}
+
+export async function deleteWorkLog(id: string): Promise<void> {
+  await api.delete(`/api/v1/work-logs/${id}`);
+}
+
+export async function getTags() {
+  const { data } = await api.get<{ id: string; name: string }[]>("/api/v1/tags");
+  return data;
+}


### PR DESCRIPTION
## Summary
- `/logs`: 로그 목록 (기분 이모지, 태그, 더 보기 페이지네이션)
- `/logs/new`: 로그 작성 (날짜/제목/내용/기분/태그, zod 검증)
- `/logs/[id]`: 상세 조회 + 인라인 수정 + 삭제 확인
- `MoodSelector`: 5가지 기분 이모지 선택 컴포넌트
- `TagInput`: 기존 태그 자동완성 + 선택/제거 컴포넌트

## Closes
Closes #59

## Test plan
- [ ] 로그 목록 조회 → 더 보기 페이지네이션 확인
- [ ] 새 로그 작성 → 목록으로 이동 확인
- [ ] 로그 수정 → 저장 확인
- [ ] 로그 삭제 → 목록으로 이동 확인
- [ ] 태그 자동완성 선택/제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)