### PR TITLE
feat(web): 회고 페이지 구현 (#60)

### DIFF
--- a/apps/web/src/app/(dashboard)/retrospectives/AiDraftModal.tsx
+++ b/apps/web/src/app/(dashboard)/retrospectives/AiDraftModal.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { format, subDays } from "date-fns";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { triggerAiDraft } from "@/lib/retrospective";
+import { useAuthStore } from "@/store/authStore";
+
+interface AiDraftModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function AiDraftModal({ onClose, onCreated }: AiDraftModalProps) {
+  const user = useAuthStore((s) => s.user);
+  const today = format(new Date(), "yyyy-MM-dd");
+  const weekAgo = format(subDays(new Date(), 6), "yyyy-MM-dd");
+
+  const [periodFrom, setPeriodFrom] = useState(weekAgo);
+  const [periodTo, setPeriodTo] = useState(today);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleGenerate = async () => {
+    if (!user) return;
+    setLoading(true);
+    setError("");
+    try {
+      await triggerAiDraft({
+        userId: user.id,
+        periodFrom,
+        periodTo,
+      });
+      onCreated();
+    } catch {
+      setError("AI 회고 생성에 실패했습니다. 잠시 후 다시 시도하세요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-sm rounded-xl border bg-card p-6 shadow-xl space-y-5">
+        <div>
+          <h2 className="text-lg font-semibold">AI 회고 초안 생성</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            기간을 선택하면 AI가 작업 로그를 분석해서 회고 초안을 작성해줍니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label>시작일</Label>
+            <Input
+              type="date"
+              value={periodFrom}
+              max={periodTo}
+              onChange={(e) => setPeriodFrom(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>종료일</Label>
+            <Input
+              type="date"
+              value={periodTo}
+              min={periodFrom}
+              max={today}
+              onChange={(e) => setPeriodTo(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex gap-3 pt-1">
+          <Button className="flex-1" onClick={handleGenerate} disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                생성 중...
+              </>
+            ) : (
+              "생성하기"
+            )}
+          </Button>
+          <Button variant="outline" className="flex-1" onClick={onClose} disabled={loading}>
+            취소
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/retrospectives/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/retrospectives/[id]/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import ReactMarkdown from "react-markdown";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getRetrospective, updateRetrospective, publishRetrospective } from "@/lib/retrospective";
+import { cn } from "@/lib/utils";
+import type { Retrospective } from "@/types";
+
+export default function RetrospectiveDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [retro, setRetro] = useState<Retrospective | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+
+  useEffect(() => {
+    getRetrospective(id).then((data) => {
+      setRetro(data);
+      setTitle(data.title);
+      setContent(data.content);
+    });
+  }, [id]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const updated = await updateRetrospective(id, { title, content });
+      setRetro(updated);
+      setIsEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!confirm("회고를 발행할까요? 발행 후에는 수정이 제한됩니다.")) return;
+    setPublishing(true);
+    try {
+      const updated = await publishRetrospective(id);
+      setRetro(updated);
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  if (!retro) return <div className="h-64 animate-pulse rounded-lg bg-muted" />;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      {/* 헤더 */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                "rounded-full px-2.5 py-0.5 text-xs font-medium",
+                retro.status === "PUBLISHED"
+                  ? "bg-primary/10 text-primary"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {retro.status === "PUBLISHED" ? "발행됨" : "초안"}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              {format(new Date(retro.periodFrom), "M월 d일", { locale: ko })} ~{" "}
+              {format(new Date(retro.periodTo), "M월 d일", { locale: ko })}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 gap-2">
+          {retro.status === "DRAFT" && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditing((v) => !v)}
+              >
+                {isEditing ? "취소" : "수정"}
+              </Button>
+              <Button size="sm" onClick={handlePublish} disabled={publishing}>
+                {publishing ? "발행 중..." : "발행"}
+              </Button>
+            </>
+          )}
+          <Button variant="ghost" size="sm" onClick={() => router.back()}>
+            뒤로
+          </Button>
+        </div>
+      </div>
+
+      {/* 내용 */}
+      {isEditing ? (
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>제목</Label>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label>내용 (마크다운)</Label>
+            <textarea
+              rows={20}
+              className="flex w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </div>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "저장 중..." : "저장"}
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card p-6">
+          <h1 className="mb-6 text-2xl font-bold">{retro.title}</h1>
+          <div className="prose prose-sm dark:prose-invert max-w-none">
+            <ReactMarkdown>{retro.content}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/retrospectives/page.tsx
+++ b/apps/web/src/app/(dashboard)/retrospectives/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AiDraftModal } from "./AiDraftModal";
+import { getRetrospectives } from "@/lib/retrospective";
+import { cn } from "@/lib/utils";
+import type { Retrospective, RetroStatus } from "@/types";
+
+const TABS: { label: string; value: RetroStatus | "ALL" }[] = [
+  { label: "전체", value: "ALL" },
+  { label: "발행됨", value: "PUBLISHED" },
+  { label: "초안", value: "DRAFT" },
+];
+
+export default function RetrospectivesPage() {
+  const [tab, setTab] = useState<RetroStatus | "ALL">("ALL");
+  const [retros, setRetros] = useState<Retrospective[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+
+  const fetchRetros = async (status?: RetroStatus) => {
+    setLoading(true);
+    try {
+      const res = await getRetrospectives({ size: 50, status });
+      setRetros(res.content);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRetros(tab === "ALL" ? undefined : tab);
+  }, [tab]);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">회고</h1>
+        <Button size="sm" onClick={() => setShowModal(true)}>
+          <Sparkles className="mr-1.5 h-4 w-4" />
+          AI 회고 초안 생성
+        </Button>
+      </div>
+
+      {/* 탭 */}
+      <div className="flex gap-1 border-b">
+        {TABS.map((t) => (
+          <button
+            key={t.value}
+            onClick={() => setTab(t.value)}
+            className={cn(
+              "px-4 py-2 text-sm font-medium transition-colors",
+              tab === t.value
+                ? "border-b-2 border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 목록 */}
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      ) : retros.length === 0 ? (
+        <p className="py-12 text-center text-muted-foreground">회고가 없습니다.</p>
+      ) : (
+        <ul className="space-y-2">
+          {retros.map((retro) => (
+            <li key={retro.id}>
+              <Link
+                href={`/retrospectives/${retro.id}`}
+                className="flex items-start justify-between rounded-lg border bg-card p-4 hover:bg-accent/50 transition-colors"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-0.5 text-xs font-medium",
+                        retro.status === "PUBLISHED"
+                          ? "bg-primary/10 text-primary"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {retro.status === "PUBLISHED" ? "발행됨" : "초안"}
+                    </span>
+                    <span className="font-medium">{retro.title}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {format(new Date(retro.periodFrom), "M월 d일", { locale: ko })} ~{" "}
+                    {format(new Date(retro.periodTo), "M월 d일", { locale: ko })}
+                  </p>
+                </div>
+                <span className="ml-4 shrink-0 text-xs text-muted-foreground">
+                  {format(new Date(retro.createdAt), "M/d")}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showModal && (
+        <AiDraftModal
+          onClose={() => setShowModal(false)}
+          onCreated={() => { setShowModal(false); fetchRetros(); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/retrospective.ts
+++ b/apps/web/src/lib/retrospective.ts
@@ -1,0 +1,44 @@
+import api from "./api";
+import type { Retrospective, PageResponse } from "@/types";
+
+export async function getRetrospectives(params?: {
+  page?: number;
+  size?: number;
+  status?: "DRAFT" | "PUBLISHED";
+}): Promise<PageResponse<Retrospective>> {
+  const { data } = await api.get<PageResponse<Retrospective>>("/api/v1/retrospectives", {
+    params,
+  });
+  return data;
+}
+
+export async function getRetrospective(id: string): Promise<Retrospective> {
+  const { data } = await api.get<Retrospective>(`/api/v1/retrospectives/${id}`);
+  return data;
+}
+
+export async function updateRetrospective(
+  id: string,
+  body: { title?: string; content?: string },
+): Promise<Retrospective> {
+  const { data } = await api.put<Retrospective>(`/api/v1/retrospectives/${id}`, body);
+  return data;
+}
+
+export async function publishRetrospective(id: string): Promise<Retrospective> {
+  const { data } = await api.post<Retrospective>(`/api/v1/retrospectives/${id}/publish`);
+  return data;
+}
+
+export async function triggerAiDraft(params: {
+  userId: string;
+  periodFrom: string;
+  periodTo: string;
+}): Promise<{ draftTitle: string; draftContent: string; goals: string[] }> {
+  const { data } = await api.post("/api/v1/agents/retrospective", {
+    user_id: params.userId,
+    period_from: params.periodFrom,
+    period_to: params.periodTo,
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary
- `/retrospectives`: 목록 (전체/발행됨/초안 탭) + AI 초안 생성 버튼
- `AiDraftModal`: 기간 선택 → AI 서버 호출 → 초안 생성 로딩 UI
- `/retrospectives/[id]`: 마크다운 렌더링 + 수정(인라인 에디터) + DRAFT→PUBLISHED 발행

## Closes
Closes #60

## Test plan
- [ ] 탭 필터 (전체/발행됨/초안) 전환 확인
- [ ] AI 초안 생성 모달 → 기간 선택 → 생성 후 목록 갱신 확인
- [ ] 회고 상세 마크다운 렌더링 확인
- [ ] 수정 후 저장 확인
- [ ] 발행 버튼 → PUBLISHED 상태 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)