### PR TITLE
feat(infra): CI/CD 배포 파이프라인 + k6 성능 테스트 (#81, #82)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,162 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: ap-northeast-2
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
+
+jobs:
+  # ── web 빌드 & ECR 푸시 ────────────────────────────────────────────────────
+  deploy-web:
+    name: Deploy Web
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('apps/web/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build & push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/web
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/grovarc-web:${{ github.sha }},${{ env.ECR_REGISTRY }}/grovarc-web:latest
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to EKS
+        uses: azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: |
+            infra/k8s/deployments/web-deployment.yaml
+            infra/k8s/services/web-service.yaml
+          images: ${{ env.ECR_REGISTRY }}/grovarc-web:${{ github.sha }}
+          namespace: grovarc
+
+  # ── api 빌드 & ECR 푸시 ────────────────────────────────────────────────────
+  deploy-api:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('apps/api/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build & push api image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/api
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/grovarc-api:${{ github.sha }},${{ env.ECR_REGISTRY }}/grovarc-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to EKS
+        uses: azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: |
+            infra/k8s/deployments/api-deployment.yaml
+            infra/k8s/services/api-service.yaml
+          images: ${{ env.ECR_REGISTRY }}/grovarc-api:${{ github.sha }}
+          namespace: grovarc
+
+  # ── ai 빌드 & ECR 푸시 ────────────────────────────────────────────────────
+  deploy-ai:
+    name: Deploy AI
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('apps/ai/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build & push ai image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/ai
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/grovarc-ai:${{ github.sha }},${{ env.ECR_REGISTRY }}/grovarc-ai:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to EKS
+        uses: azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: |
+            infra/k8s/deployments/ai-deployment.yaml
+            infra/k8s/services/ai-service.yaml
+          images: ${{ env.ECR_REGISTRY }}/grovarc-ai:${{ github.sha }}
+          namespace: grovarc
+
+  # ── mcp 빌드 & ECR 푸시 ───────────────────────────────────────────────────
+  deploy-mcp:
+    name: Deploy MCP
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('apps/mcp/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build & push mcp image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/mcp
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/grovarc-mcp:${{ github.sha }},${{ env.ECR_REGISTRY }}/grovarc-mcp:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to EKS
+        uses: azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: |
+            infra/k8s/deployments/mcp-deployment.yaml
+            infra/k8s/services/mcp-service.yaml
+          images: ${{ env.ECR_REGISTRY }}/grovarc-mcp:${{ github.sha }}
+          namespace: grovarc

--- a/infra/k6/ai-test.js
+++ b/infra/k6/ai-test.js
@@ -1,0 +1,62 @@
+/**
+ * AI 서버 성능 테스트 (k6)
+ * 코칭 Agent 응답 시간 측정 (LangGraph 실행 포함)
+ *
+ * 실행:
+ *   k6 run --env AI_URL=http://localhost:8000 \
+ *           --env USER_ID=test-user-id \
+ *           infra/k6/ai-test.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const AI_URL = __ENV.AI_URL || "http://localhost:8000";
+const USER_ID = __ENV.USER_ID || "test-user-id";
+
+const coachingDuration = new Trend("coaching_agent_duration");
+const errorRate = new Rate("error_rate");
+
+export const options = {
+  // AI Agent는 무거우므로 낮은 VU로 테스트
+  stages: [
+    { duration: "30s", target: 3 },
+    { duration: "2m", target: 5 },
+    { duration: "30s", target: 0 },
+  ],
+  thresholds: {
+    // 코칭 Agent는 LLM 호출이 포함되므로 여유 있게 설정
+    coaching_agent_duration: ["p(95)<120000"], // 95%ile 2분 이내
+    error_rate: ["rate<0.10"],
+  },
+};
+
+export default function () {
+  // 코칭 Agent 실행 (LangGraph + RAG + 웹 검색 포함)
+  const res = http.post(
+    `${AI_URL}/api/v1/agents/coaching`,
+    JSON.stringify({ user_id: USER_ID }),
+    {
+      headers: { "Content-Type": "application/json" },
+      timeout: "180s",  // Agent 최대 3분 허용
+    },
+  );
+
+  coachingDuration.add(res.timings.duration);
+
+  const ok = check(res, {
+    "coaching 200": (r) => r.status === 200,
+    "has roadmap": (r) => {
+      try {
+        return r.json("roadmap")?.length > 0;
+      } catch {
+        return false;
+      }
+    },
+  });
+  errorRate.add(!ok);
+
+  // Agent 실행 간격 (서버 부하 방지)
+  sleep(5);
+}

--- a/infra/k6/load-test.js
+++ b/infra/k6/load-test.js
@@ -1,0 +1,103 @@
+/**
+ * Grovarc 부하 테스트 (k6)
+ *
+ * 실행:
+ *   k6 run --env BASE_URL=http://localhost:8080 \
+ *           --env EMAIL=test@grovarc.dev \
+ *           --env PASSWORD=Test1234! \
+ *           infra/k6/load-test.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const EMAIL = __ENV.EMAIL || "test@grovarc.dev";
+const PASSWORD = __ENV.PASSWORD || "Test1234!";
+
+// 커스텀 메트릭
+const loginDuration = new Trend("login_duration");
+const logListDuration = new Trend("log_list_duration");
+const logCreateDuration = new Trend("log_create_duration");
+const coachingDuration = new Trend("coaching_duration");
+const errorRate = new Rate("error_rate");
+
+export const options = {
+  stages: [
+    { duration: "30s", target: 10 },   // 워밍업: 10명까지 증가
+    { duration: "1m", target: 50 },    // 부하: 50명 유지
+    { duration: "30s", target: 100 },  // 스파이크: 100명
+    { duration: "1m", target: 50 },    // 안정화: 50명
+    { duration: "30s", target: 0 },    // 쿨다운
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<2000"],  // 95%ile 2초 이내
+    http_req_failed: ["rate<0.05"],     // 실패율 5% 미만
+    login_duration: ["p(95)<1000"],     // 로그인 1초 이내
+    log_list_duration: ["p(95)<500"],   // 목록 조회 500ms 이내
+    log_create_duration: ["p(95)<1000"], // 로그 작성 1초 이내
+    error_rate: ["rate<0.05"],
+  },
+};
+
+// 로그인 후 토큰 반환
+function login() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+
+  loginDuration.add(res.timings.duration);
+  const ok = check(res, { "login 200": (r) => r.status === 200 });
+  errorRate.add(!ok);
+
+  if (!ok) return null;
+  return res.json("accessToken");
+}
+
+export default function () {
+  // 1. 로그인
+  const token = login();
+  if (!token) return;
+
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+
+  sleep(0.5);
+
+  // 2. 작업 로그 목록 조회
+  const listRes = http.get(`${BASE_URL}/api/v1/work-logs`, { headers });
+  logListDuration.add(listRes.timings.duration);
+  check(listRes, { "log list 200": (r) => r.status === 200 });
+  errorRate.add(listRes.status !== 200);
+
+  sleep(0.5);
+
+  // 3. 작업 로그 작성
+  const createRes = http.post(
+    `${BASE_URL}/api/v1/work-logs`,
+    JSON.stringify({
+      title: `k6 부하 테스트 로그 ${Date.now()}`,
+      content: "k6로 자동 생성된 테스트 로그입니다.",
+      logDate: new Date().toISOString().split("T")[0],
+      mood: "GOOD",
+    }),
+    { headers },
+  );
+  logCreateDuration.add(createRes.timings.duration);
+  check(createRes, { "log create 201": (r) => r.status === 201 });
+  errorRate.add(createRes.status !== 201);
+
+  sleep(0.5);
+
+  // 4. 회고 목록 조회
+  const retroRes = http.get(`${BASE_URL}/api/v1/retrospectives`, { headers });
+  check(retroRes, { "retro list 200": (r) => r.status === 200 });
+  errorRate.add(retroRes.status !== 200);
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- `deploy.yml`: main 브랜치 푸시 시 4개 서비스 자동 배포 (ECR → EKS 롤링)
  - GitHub Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ACCOUNT_ID`, `NEXT_PUBLIC_API_URL`
  - 각 서비스 독립 job으로 병렬 배포
- `infra/k6/load-test.js`: API 서버 부하 테스트
  - VU 10→50→100 단계적 증가
  - 임계값: p(95) 응답시간, 실패율 5% 미만
- `infra/k6/ai-test.js`: AI 코칭 Agent 성능 측정
  - LangGraph + RAG 포함, 낮은 VU(5) + 2분 타임아웃

## 실행 방법
```bash
# API 부하 테스트
k6 run --env BASE_URL=https://api.grovarc.dev infra/k6/load-test.js

# AI Agent 성능 테스트
k6 run --env AI_URL=https://ai.grovarc.dev infra/k6/ai-test.js
```

Closes #81
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)